### PR TITLE
Add new Yealink MWI Subscribe Variable

### DIFF
--- a/resources/templates/provision/yealink/t19p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t19p/{$mac}.cfg
@@ -169,7 +169,7 @@ account.1.auto_answer =
 account.1.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm =
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
 account.1.register_mac =
@@ -492,7 +492,7 @@ account.2.auto_answer =
 account.2.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm =
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address in the Register message; 0-Disabled (default), 1-Enabled;
 account.2.register_mac =
@@ -813,7 +813,7 @@ account.3.auto_answer =
 account.3.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm =
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address in the Register message; 0-Disabled (default), 1-Enabled;
 account.3.register_mac =
@@ -1134,7 +1134,7 @@ account.4.auto_answer =
 account.4.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm =
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address in the Register message; 0-Disabled (default), 1-Enabled;
 account.4.register_mac =
@@ -1458,7 +1458,7 @@ account.5.auto_answer =
 account.5.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm =
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
 account.5.register_mac =
@@ -1777,7 +1777,7 @@ account.6.auto_answer =
 account.6.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
 account.6.register_mac =

--- a/resources/templates/provision/yealink/t20p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t20p/{$mac}.cfg
@@ -169,7 +169,7 @@ account.1.auto_answer =
 account.1.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm =
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
 account.1.register_mac =
@@ -492,7 +492,7 @@ account.2.auto_answer =
 account.2.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm =
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address in the Register message; 0-Disabled (default), 1-Enabled;
 account.2.register_mac =
@@ -813,7 +813,7 @@ account.3.auto_answer =
 account.3.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm =
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address in the Register message; 0-Disabled (default), 1-Enabled;
 account.3.register_mac =
@@ -1134,7 +1134,7 @@ account.4.auto_answer =
 account.4.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm =
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address in the Register message; 0-Disabled (default), 1-Enabled;
 account.4.register_mac =
@@ -1458,7 +1458,7 @@ account.5.auto_answer =
 account.5.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm =
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
 account.5.register_mac =
@@ -1777,7 +1777,7 @@ account.6.auto_answer =
 account.6.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
 account.6.register_mac =

--- a/resources/templates/provision/yealink/t21p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t21p/{$mac}.cfg
@@ -176,7 +176,7 @@ account.1.subscribe_mwi = 1
 account.1.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm = 1
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.1.subscribe_acd_expires= 3600
 
@@ -642,7 +642,7 @@ account.2.subscribe_mwi = 1
 account.2.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm = 1
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.2.subscribe_acd_expires= 3600
 
@@ -1152,7 +1152,7 @@ account.3.subscribe_mwi = 1
 account.3.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm = 1
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.3.subscribe_acd_expires= 3600
 
@@ -1645,7 +1645,7 @@ account.4.subscribe_mwi = 1
 account.4.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm = 1
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.4.subscribe_acd_expires= 3600
 
@@ -2137,7 +2137,7 @@ account.5.subscribe_mwi = 1
 account.5.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm = 1
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.5.subscribe_acd_expires= 3600
 
@@ -2628,7 +2628,7 @@ account.6.subscribe_mwi = 0
 account.6.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.6.subscribe_acd_expires= 3600
 

--- a/resources/templates/provision/yealink/t22p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t22p/{$mac}.cfg
@@ -170,7 +170,7 @@ account.1.auto_answer =
 account.1.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm =
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
 account.1.register_mac =
@@ -491,7 +491,7 @@ account.2.auto_answer =
 account.2.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm =
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address in the Register message; 0-Disabled (default), 1-Enabled;
 account.2.register_mac =
@@ -812,7 +812,7 @@ account.3.auto_answer =
 account.3.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm =
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address in the Register message; 0-Disabled (default), 1-Enabled;
 account.3.register_mac =
@@ -1134,7 +1134,7 @@ account.4.auto_answer =
 account.4.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm =
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address in the Register message; 0-Disabled (default), 1-Enabled;
 account.4.register_mac =
@@ -1458,7 +1458,7 @@ account.5.auto_answer =
 account.5.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm =
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
 account.5.register_mac =
@@ -1777,7 +1777,7 @@ account.6.auto_answer =
 account.6.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
 account.6.register_mac =

--- a/resources/templates/provision/yealink/t23g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t23g/{$mac}.cfg
@@ -174,7 +174,7 @@ account.1.subscribe_mwi = 1
 account.1.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm = 1
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.1.subscribe_acd_expires= 3600
 
@@ -639,7 +639,7 @@ account.2.subscribe_mwi = 1
 account.2.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm = 1
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.2.subscribe_acd_expires= 3600
 
@@ -1148,7 +1148,7 @@ account.3.subscribe_mwi = 1
 account.3.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm = 1
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.3.subscribe_acd_expires= 3600
 
@@ -1639,7 +1639,7 @@ account.4.subscribe_mwi = 1
 account.4.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm = 1
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.4.subscribe_acd_expires= 3600
 
@@ -2130,7 +2130,7 @@ account.5.subscribe_mwi = 1
 account.5.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm = 1
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.5.subscribe_acd_expires= 3600
 
@@ -2620,7 +2620,7 @@ account.6.subscribe_mwi = 0
 account.6.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.6.subscribe_acd_expires= 3600
 

--- a/resources/templates/provision/yealink/t23p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t23p/{$mac}.cfg
@@ -174,7 +174,7 @@ account.1.subscribe_mwi = 1
 account.1.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm = 1
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.1.subscribe_acd_expires= 3600
 
@@ -639,7 +639,7 @@ account.2.subscribe_mwi = 1
 account.2.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm = 1
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.2.subscribe_acd_expires= 3600
 
@@ -1148,7 +1148,7 @@ account.3.subscribe_mwi = 1
 account.3.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm = 1
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.3.subscribe_acd_expires= 3600
 
@@ -1639,7 +1639,7 @@ account.4.subscribe_mwi = 1
 account.4.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm = 1
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.4.subscribe_acd_expires= 3600
 
@@ -2130,7 +2130,7 @@ account.5.subscribe_mwi = 1
 account.5.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm = 1
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.5.subscribe_acd_expires= 3600
 
@@ -2620,7 +2620,7 @@ account.6.subscribe_mwi = 0
 account.6.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.6.subscribe_acd_expires= 3600
 

--- a/resources/templates/provision/yealink/t26p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t26p/{$mac}.cfg
@@ -169,7 +169,7 @@ account.1.auto_answer =
 account.1.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm =
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
 account.1.register_mac =
@@ -491,7 +491,7 @@ account.2.auto_answer =
 account.2.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm =
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address in the Register message; 0-Disabled (default), 1-Enabled;
 account.2.register_mac =
@@ -812,7 +812,7 @@ account.3.auto_answer =
 account.3.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm =
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address in the Register message; 0-Disabled (default), 1-Enabled;
 account.3.register_mac =
@@ -1133,7 +1133,7 @@ account.4.auto_answer =
 account.4.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm =
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address in the Register message; 0-Disabled (default), 1-Enabled;
 account.4.register_mac =
@@ -1457,7 +1457,7 @@ account.5.auto_answer =
 account.5.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm =
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
 account.5.register_mac =
@@ -1776,7 +1776,7 @@ account.6.auto_answer =
 account.6.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
 account.6.register_mac =

--- a/resources/templates/provision/yealink/t27g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t27g/{$mac}.cfg
@@ -175,7 +175,7 @@ account.1.subscribe_mwi = 1
 account.1.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm = 1
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.1.subscribe_acd_expires= 3600
 
@@ -640,7 +640,7 @@ account.2.subscribe_mwi = 1
 account.2.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm = 1
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.2.subscribe_acd_expires= 3600
 
@@ -1149,7 +1149,7 @@ account.3.subscribe_mwi = 1
 account.3.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm = 1
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.3.subscribe_acd_expires= 3600
 
@@ -1640,7 +1640,7 @@ account.4.subscribe_mwi = 1
 account.4.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm = 1
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.4.subscribe_acd_expires= 3600
 
@@ -2131,7 +2131,7 @@ account.5.subscribe_mwi = 1
 account.5.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm = 1
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.5.subscribe_acd_expires= 3600
 
@@ -2621,7 +2621,7 @@ account.6.subscribe_mwi = 0
 account.6.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.6.subscribe_acd_expires= 3600
 

--- a/resources/templates/provision/yealink/t27p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t27p/{$mac}.cfg
@@ -175,7 +175,7 @@ account.1.subscribe_mwi = 1
 account.1.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm = 1
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.1.subscribe_acd_expires= 3600
 
@@ -640,7 +640,7 @@ account.2.subscribe_mwi = 1
 account.2.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm = 1
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.2.subscribe_acd_expires= 3600
 
@@ -1149,7 +1149,7 @@ account.3.subscribe_mwi = 1
 account.3.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm = 1
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.3.subscribe_acd_expires= 3600
 
@@ -1640,7 +1640,7 @@ account.4.subscribe_mwi = 1
 account.4.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm = 1
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.4.subscribe_acd_expires= 3600
 
@@ -2131,7 +2131,7 @@ account.5.subscribe_mwi = 1
 account.5.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm = 1
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.5.subscribe_acd_expires= 3600
 
@@ -2621,7 +2621,7 @@ account.6.subscribe_mwi = 0
 account.6.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.6.subscribe_acd_expires= 3600
 

--- a/resources/templates/provision/yealink/t28p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t28p/{$mac}.cfg
@@ -170,7 +170,7 @@ account.1.auto_answer =
 account.1.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm =
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
 account.1.register_mac =
@@ -491,7 +491,7 @@ account.2.auto_answer =
 account.2.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm =
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address in the Register message; 0-Disabled (default), 1-Enabled;
 account.2.register_mac =
@@ -813,7 +813,7 @@ account.3.auto_answer =
 account.3.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm =
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address in the Register message; 0-Disabled (default), 1-Enabled;
 account.3.register_mac =
@@ -1134,7 +1134,7 @@ account.4.auto_answer =
 account.4.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm =
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address in the Register message; 0-Disabled (default), 1-Enabled;
 account.4.register_mac =
@@ -1458,7 +1458,7 @@ account.5.auto_answer =
 account.5.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm =
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
 account.5.register_mac =
@@ -1777,7 +1777,7 @@ account.6.auto_answer =
 account.6.missed_calllog =
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 #Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
 account.6.register_mac =

--- a/resources/templates/provision/yealink/t29g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t29g/{$mac}.cfg
@@ -175,7 +175,7 @@ account.1.subscribe_mwi = 1
 account.1.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm = 1
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.1.subscribe_acd_expires= 3600
 
@@ -636,7 +636,7 @@ account.2.subscribe_mwi = 1
 account.2.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm = 1
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.2.subscribe_acd_expires= 3600
 
@@ -1145,7 +1145,7 @@ account.3.subscribe_mwi = 1
 account.3.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm = 1
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.3.subscribe_acd_expires= 3600
 
@@ -1636,7 +1636,7 @@ account.4.subscribe_mwi = 1
 account.4.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm = 1
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.4.subscribe_acd_expires= 3600
 
@@ -2127,7 +2127,7 @@ account.5.subscribe_mwi = 1
 account.5.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm = 1
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.5.subscribe_acd_expires= 3600
 
@@ -2625,7 +2625,7 @@ account.6.subscribe_mwi = 0
 account.6.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.6.subscribe_acd_expires= 3600
 

--- a/resources/templates/provision/yealink/t40p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t40p/{$mac}.cfg
@@ -175,7 +175,7 @@ account.1.subscribe_mwi = 1
 account.1.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm = 1
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.1.subscribe_acd_expires= 3600
 
@@ -640,7 +640,7 @@ account.2.subscribe_mwi = 1
 account.2.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm = 1
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.2.subscribe_acd_expires= 3600
 
@@ -1149,7 +1149,7 @@ account.3.subscribe_mwi = 1
 account.3.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm = 1
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.3.subscribe_acd_expires= 3600
 
@@ -1640,7 +1640,7 @@ account.4.subscribe_mwi = 1
 account.4.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm = 1
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.4.subscribe_acd_expires= 3600
 
@@ -2131,7 +2131,7 @@ account.5.subscribe_mwi = 1
 account.5.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm = 1
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.5.subscribe_acd_expires= 3600
 
@@ -2621,7 +2621,7 @@ account.6.subscribe_mwi = 0
 account.6.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.6.subscribe_acd_expires= 3600
 

--- a/resources/templates/provision/yealink/t41p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t41p/{$mac}.cfg
@@ -175,7 +175,7 @@ account.1.subscribe_mwi = 1
 account.1.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm = 1
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.1.subscribe_acd_expires= 3600
 
@@ -640,7 +640,7 @@ account.2.subscribe_mwi = 1
 account.2.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm = 1
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.2.subscribe_acd_expires= 3600
 
@@ -1149,7 +1149,7 @@ account.3.subscribe_mwi = 1
 account.3.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm = 1
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.3.subscribe_acd_expires= 3600
 
@@ -1640,7 +1640,7 @@ account.4.subscribe_mwi = 1
 account.4.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm = 1
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.4.subscribe_acd_expires= 3600
 
@@ -2131,7 +2131,7 @@ account.5.subscribe_mwi = 1
 account.5.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm = 1
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.5.subscribe_acd_expires= 3600
 
@@ -2621,7 +2621,7 @@ account.6.subscribe_mwi = 0
 account.6.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.6.subscribe_acd_expires= 3600
 

--- a/resources/templates/provision/yealink/t41s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t41s/{$mac}.cfg
@@ -175,7 +175,7 @@ account.1.subscribe_mwi = 1
 account.1.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm = 1
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.1.subscribe_acd_expires= 3600
 
@@ -640,7 +640,7 @@ account.2.subscribe_mwi = 1
 account.2.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm = 1
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.2.subscribe_acd_expires= 3600
 
@@ -1149,7 +1149,7 @@ account.3.subscribe_mwi = 1
 account.3.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm = 1
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.3.subscribe_acd_expires= 3600
 
@@ -1640,7 +1640,7 @@ account.4.subscribe_mwi = 1
 account.4.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm = 1
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.4.subscribe_acd_expires= 3600
 
@@ -2131,7 +2131,7 @@ account.5.subscribe_mwi = 1
 account.5.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm = 1
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.5.subscribe_acd_expires= 3600
 
@@ -2621,7 +2621,7 @@ account.6.subscribe_mwi = 0
 account.6.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.6.subscribe_acd_expires= 3600
 

--- a/resources/templates/provision/yealink/t42g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t42g/{$mac}.cfg
@@ -175,7 +175,7 @@ account.1.subscribe_mwi = 1
 account.1.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm = 1
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.1.subscribe_acd_expires= 3600
 
@@ -640,7 +640,7 @@ account.2.subscribe_mwi = 1
 account.2.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm = 1
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.2.subscribe_acd_expires= 3600
 
@@ -1149,7 +1149,7 @@ account.3.subscribe_mwi = 1
 account.3.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm = 1
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.3.subscribe_acd_expires= 3600
 
@@ -1640,7 +1640,7 @@ account.4.subscribe_mwi = 1
 account.4.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm = 1
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.4.subscribe_acd_expires= 3600
 
@@ -2131,7 +2131,7 @@ account.5.subscribe_mwi = 1
 account.5.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm = 1
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.5.subscribe_acd_expires= 3600
 
@@ -2621,7 +2621,7 @@ account.6.subscribe_mwi = 0
 account.6.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.6.subscribe_acd_expires= 3600
 

--- a/resources/templates/provision/yealink/t42s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t42s/{$mac}.cfg
@@ -1,81 +1,12 @@
 #!version:1.0.0.1
 
 ##File header "#!version:1.0.0.1" can not be edited or deleted, and must be placed in the first line.##
-##account.X.*:(T54S/T48G/T48S/T46G/T46S/T29G: X ranges from 1 to 16. T52S/T42G/T42S: X ranges from 1 to 12. T41P/T41S/T27P/T27G: X ranges from 1 to 6. T40P/T40G/T23P/T23G: X ranges from 1 to 3. T21(P) E2: X ranges from 1 to 2.)##
 
 #######################################################################################
-##                                   Transfer                                        ##       
+##                           Account 1 Basic Settings                                ##
 #######################################################################################
-account.1.phone_setting.call_appearance.transfer_via_new_linekey=
-
-
-#######################################################################################
-##                                   Conference                                      ##       
-#######################################################################################
-account.1.phone_setting.call_appearance.conference_via_new_linekey=
-
-
-#######################################################################################
-##                                   Anonymous                                       ##       
-#######################################################################################
-account.1.anonymous_call.server_base_only =
-account.1.send_anonymous_rejection_code =
-account.1.anonymous_reject_offcode =
-account.1.anonymous_reject_oncode =
-account.1.reject_anonymous_call=
-account.1.anonymous_call_offcode =
-account.1.anonymous_call_oncode =
-account.1.anonymous_call =
-account.1.send_anonymous_code =
-
-
-
-#######################################################################################
-##                          Call Configuration                                       ##       
-#######################################################################################
-account.1.music_server_uri=
-account.1.music_on_hold_type=
-account.1.auto_label.rule=
-account.1.auto_label.enable=
-account.1.number_of_linekey=
-account.1.phone_setting.call_appearance.calls_per_linekey=
-
-
-#######################################################################################
-##                                    Codec                                          ##       
-#######################################################################################
-account.1.codec.ilbc_15_2kbps.priority=
-account.1.codec.ilbc_15_2kbps.enable=
-account.1.codec.ilbc_13_33kbps.priority=
-account.1.codec.ilbc_13_33kbps.enable =
-account.1.codec.pcma.enable=
-account.1.codec.pcma.priority=
-account.1.codec.pcmu.enable=
-account.1.codec.pcmu.priority=
-account.1.codec.opus.priority =
-account.1.codec.opus.enable=
-account.1.codec.opus.para=
-account.1.codec.g726_40.enable=
-account.1.codec.g726_40.priority=
-account.1.codec.g726_32.enable=
-account.1.codec.g726_32.priority=
-account.1.codec.g726_24.enable=
-account.1.codec.g726_24.priority=
-account.1.codec.g726_16.enable=
-account.1.codec.g726_16.priority=
-account.1.codec.g723_63.priority=
-account.1.codec.g723_63.enable=
-account.1.codec.g723_53.priority=
-account.1.codec.g723_53.enable=
-account.1.codec.g729.priority=
-account.1.codec.g729.enable=
-account.1.codec.g722.priority=
-account.1.codec.g722.enable=
-
-################################################################
-#                      Account Register                       ##
-################################################################
-
+## ranges from 1 to 6;
+##account.X.enable =
 {if isset($user_password_1) }
 account.1.enable = 1
 {else}
@@ -86,335 +17,464 @@ account.1.display_name = {$display_name_1}
 account.1.auth_name = {$auth_id_1}
 account.1.password = {$user_password_1}
 account.1.user_name = {$user_id_1}
+account.1.sip_server_host = {$server_address_1}
+account.1.sip_server_port = {$sip_port_1}
+account.1.outbound_host = {$outbound_proxy_1}
+account.1.outbound_port = {$sip_port_1}
+{if isset($yealink_sip_listen_port)}account.1.sip_listen_port = {$yealink_sip_listen_port}{else}account.1.sip_listen_port = 5060{/if}
 
-account.1.sip_server.1.address = {$server_address_1}
-account.1.sip_server.1.port = {$sip_port_1}
-
-{if $sip_transport_1 == 'udp'}account.1.sip_server.1.transport_type = 0{/if}
-{if $sip_transport_1 == 'tcp'}account.1.sip_server.1.transport_type = 1{/if}
-{if $sip_transport_1 == 'tls'}account.1.sip_server.1.transport_type = 2{/if}
-{if $sip_transport_1 == 'dns srv'}account.1.sip_server.1.transport_type = 3{/if}
-
-account.1.sip_server.1.expires = {$register_expires_1}
-account.1.sip_server.1.retry_counts = 3
-
-account.1.sip_server.2.address = {$server_address_2}
-account.1.sip_server.2.port = {$sip_port_2}
-
-{if $sip_transport_1 == 'udp'}account.1.sip_server.2.transport_type = 0{/if}
-{if $sip_transport_1 == 'tcp'}account.1.sip_server.2.transport_type = 1{/if}
-{if $sip_transport_1 == 'tls'}account.1.sip_server.2.transport_type = 2{/if}
-{if $sip_transport_1 == 'dns srv'}account.1.sip_server.2.transport_type = 3{/if}
-
-account.1.sip_server.2.expires = {$register_expires_2}
-account.1.sip_server.2.retry_counts = 3
-
-account.1.outbound_proxy_enable = {if isset($outbound_proxy_primary_1)}1{else}0{/if}
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS SRV;
+{if $sip_transport_1 == 'udp'}account.1.transport = 0{/if}
+{if $sip_transport_1 == 'tcp'}account.1.transport = 1{/if}
+{if $sip_transport_1 == 'tls'}account.1.transport = 2{/if}
+{if $sip_transport_1 == 'dns srv'}account.1.transport = 3{/if}
 
 account.1.outbound_proxy.1.address = {$outbound_proxy_primary_1}
+account.1.outbound_proxy.2.address = {$outbound_proxy_secondary_1}
+account.1.outbound_proxy_enable = {if isset($outbound_proxy_primary_1)}1{else}0{/if}
 
 {if isset($outbound_proxy_1_port)}
 account.1.outbound_proxy.1.port = {$outbound_proxy_1_port}
 {else}
 account.1.outbound_proxy.1.port = 5060
 {/if}
-
-account.1.outbound_proxy.2.address = {$outbound_proxy_secondary_1}
-
 {if isset($outbound_proxy_1_port)}
 account.1.outbound_proxy.2.port = {$outbound_proxy_2_port}
 {else}
 account.1.outbound_proxy.2.port = 5060
 {/if}
 
-{if isset($outbound_proxy_fallback_interval)}
-account.1.outbound_proxy_fallback_interval = {$outbound_proxy_fallback_interval}
-{else}
-account.1.outbound_proxy_fallback_interval = 120
-{/if}
+#######################################################################################
+##                          Failback                                                 ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.reregister_enable = 0
 
+account.1.reregister_enable = 0
+account.1.retry_counts =
+account.1.failback_mode = 0
+account.1.failback_timeout = 3600
+account.1.naptr_build = 0
+account.1.fallback.redundancy_type = 0
+account.1.fallback.timeout = {$yealink_outbound_proxy_fallback_interval}
+account.1.sip_server.1.address =
+{if $sip_transport_1 == 'dns srv'}
+account.1.sip_server.1.port = 0
+{else}
+account.1.sip_server.1.port = {$sip_port_1}
+{/if}
+#Configure the register expiry time (in seconds), the default value is 3600.
+account.1.sip_server.1.expires = {$register_expires_1}
+account.1.sip_server.1.retry_counts = 3
+account.1.sip_server.1.failback_mode = 0
+account.1.sip_server.1.failback_timeout = 3600
+account.1.sip_server.1.register_on_enable = 0
+account.1.sip_server.2.address =
+account.1.sip_server.2.port = 5060
+account.1.sip_server.2.expires = 3600
+account.1.sip_server.2.retry_counts = 3
+account.1.sip_server.2.failback_mode = 0
+account.1.sip_server.2.failback_timeout = 3600
+account.1.sip_server.2.register_on_enable = 0
+account.1.dns_cache_type = 1
+
+account.1.dns_cache_a.1.name =
+account.1.dns_cache_a.1.ip =
+account.1.dns_cache_a.1.ttl = 300
+
+account.1.dns_cache_srv.1.name =
+account.1.dns_cache_srv.1.port = 0
+account.1.dns_cache_srv.1.priority = 0
+account.1.dns_cache_srv.1.target =
+account.1.dns_cache_srv.1.weight = 0
+account.1.dns_cache_srv.1.ttl = 300
+account.1.dns_cache_naptr.1.name =
+account.1.dns_cache_naptr.1.flags =
+account.1.dns_cache_naptr.1.order = 0
+account.1.dns_cache_naptr.1.preference = 0
+account.1.dns_cache_naptr.1.replace =
+account.1.dns_cache_naptr.1.service =
+account.1.dns_cache_naptr.1.ttl = 300
+
+account.1.static_cache_pri = 0
+
+#######################################################################################
+##                           Register Advanced                                       ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.sip_server_type =
+
+#Configure the SIP server type; 0-Default (default), 2-BroadSoft, 4-Cosmocom;
+account.1.sip_server_type =
+#Enable or disable the phone to send the account log-off message first and then send account register message when rebooting the phone; 0-Disabled (default), 1-Enabled;
+account.1.unregister_on_reboot =
+
+#Enable or disable the phone to only accept the message from the server; 0-Disabled (default), 1-Enabled;
+account.1.sip_trust_ctrl = 1
+
+#Configure the timeout (in seconds) for DNS query, the value ranges from 1 to 9, the default value is 8.
+account.1.dns_query_timeout=
+
+#Enable or disable the timer to periodically refresh the DNS-SRV query result; 0-Disabled (default), 1-Enabled;
+account.1.srv_ttl_timer_enable =
+account.1.proxy_require =
+
+
+#Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
+account.1.register_mac =
+account.1.register_line =
+
+#Configure the interval (in seconds) the phone retries to register when account1 fails to register. It ranges from 0 to 1800, the default value is 30.
+account.1.reg_fail_retry_interval =
+
+#########################################################################
+##                     NAT Settings                                    ##
+#########################################################################
+
+#Enable or disable the NAT traversal; 0-Disabled (default), 1-STUN;
 account.1.nat.nat_traversal = {if isset($stun_server)}1{else}0{/if}
 
-################################################################
-#                      Account Basic                          ##
-################################################################
-account.1.proxy_require=
-account.1.auto_answer=
+#Configure the STUN server address.
+account.1.nat.stun_server = {$stun_server}
 
-################################################################
-#                      Account Advanced                       ##
-################################################################
-account.1.nat.udp_update_enable= 3
-account.1.nat.udp_update_time= 30
-account.1.nat.rport= {$yealink_rport}
+#Configure the STUN server port, the default value is 3478.
+account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-account.1.dtmf.type=
-account.1.dtmf.info_type=
-account.1.dtmf.dtmf_payload=
-account.1.100rel_enable= {$yealink_retransmission}
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.1.nat.udp_update_enable = 3
 
-account.1.subscribe_register=
-account.1.cid_source = {$yealink_cid_source}
-account.1.enable_user_equal_phone=
+#Specify the keep-alive interval (in seconds), the default value is 30.
+account.1.nat.udp_update_time = 30
+
+#Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
+account.1.nat.rport = {$yealink_rport}
+
+
+#######################################################################################
+##                            AccountX Advance Settings                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.advanced.timer_t1 = 0.5
+##voice_mail.number.X =
+
+#Configure the session timer (in seconds), the default value of T1, T2, T3 is 0.5, 4, 5.
+account.1.advanced.timer_t1 =
+account.1.advanced.timer_t2 =
+account.1.advanced.timer_t4 =
+
+voice_mail.number.1 = {$voicemail_number}
+
+
+#######################################################################################
+##                            Subscribe                                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.subscribe_mwi =
+
+account.1.subscribe_mwi = 1
+account.1.subscribe_mwi_expires = 3600
+
+#Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
+
+account.1.subscribe_acd_expires= 3600
+
+
+#######################################################################################
+##                            BLF List                                               ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.blf.blf_list_uri =
+
+#Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
+account.1.blf.blf_list_uri =
+
+account.1.blf_list_code =
+account.1.blf_list_barge_in_code =
+account.1.blf.subscribe_period = 1800
+
+account.1.blf.subscribe_event =
+account.1.out_dialog_blf_enable = 0
+
+
+#######################################################################################
+##                            BLA/SCA                                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.shared_line =
+
+#Assign account1 as shared line; 0-Disabled (default), 1-Broadsoft SCA, 2-BLA;
+{if isset($shared_line_1) }
+account.1.shared_line = {$shared_line_1}
+{else}
+account.1.shared_line = 0
+{/if}
+
+#Configure BLA number for account1 and the subscribe period (in seconds). It ranges from 60 to 7200, the default value is 300.
+account.1.bla_number =
+account.1.bla_subscribe_period = 300
+
+#######################################################################################
+##                            Audio Codec                                            ##
+#######################################################################################
+#Audio codecs for account1 (Y ranges from 1 to 11).
+#Enable or disable the specified codec; 0-Disabled, 1-Enabled;
+#account.1.codec.Y.enable =
+#The type of the specified codec.
+#account.1.codec.Y.payload_type =
+#The priority of the specified codec. It's available when the codec is enabled.
+#account.1.codec.Y.priority =
+#The payload of the specified codec.
+#account.1.codec.Y.rtpmap =
+
+account.1.codec.1.enable = 1
+account.1.codec.1.payload_type = PCMU
+account.1.codec.1.priority = 2
+account.1.codec.1.rtpmap = 0
+
+account.1.codec.2.enable = 1
+account.1.codec.2.payload_type = PCMA
+account.1.codec.2.priority = 3
+account.1.codec.2.rtpmap = 8
+
+account.1.codec.3.enable = 0
+account.1.codec.3.payload_type = G723_53
+account.1.codec.3.priority =0
+account.1.codec.3.rtpmap = 4
+
+account.1.codec.4.enable = 0
+account.1.codec.4.payload_type = G723_63
+account.1.codec.4.priority = 0
+account.1.codec.4.rtpmap = 4
+
+account.1.codec.5.enable = 1
+account.1.codec.5.payload_type = G729
+account.1.codec.5.priority = 3
+account.1.codec.5.rtpmap = 18
+
+account.1.codec.6.enable = 1
+account.1.codec.6.payload_type = G722
+account.1.codec.6.priority = 1
+account.1.codec.6.rtpmap = 9
+
+account.1.codec.7.enable = 0
+account.1.codec.7.payload_type = iLBC
+account.1.codec.7.priority =  0
+account.1.codec.7.rtpmap = 106
+
+account.1.codec.8.enable = 0
+account.1.codec.8.payload_type = G726-16
+account.1.codec.8.priority = 0
+account.1.codec.8.rtpmap = 103
+
+account.1.codec.9.enable = 0
+account.1.codec.9.payload_type = G726-24
+account.1.codec.9.priority = 0
+account.1.codec.9.rtpmap = 104
+
+account.1.codec.10.enable = 0
+account.1.codec.10.payload_type = G726-32
+account.1.codec.10.priority = 0
+account.1.codec.10.rtpmap = 102
+
+account.1.codec.11.enable = 0
+account.1.codec.11.payload_type = G726-40
+account.1.codec.11.priority = 0
+account.1.codec.11.rtpmap = 105
+
+account.1.codec.12.enable = 0
+account.1.codec.12.payload_type = GSM
+account.1.codec.12.priority = 0
+account.1.codec.12.rtpmap = 3
+
+
+#######################################################################################
+##                            Audio Advanced                                         ##
+#######################################################################################
+#Specify whether to encrypt the SIP messages; 0-Disabled (default), 1-Forced, 2-Negotiated;
 account.1.srtp_encryption = {$yealink_srtp_encryption}
-account.1.ptime= 20
-account.1.register_line=
-account.1.register_mac=
-account.1.reg_fail_retry_interval=
-account.1.unregister_on_reboot=
 
-account.1.session_timer.refresher=
-account.1.session_timer.expires=
+#Configure the RTP packet time. The valid values are 0 (Disabled), 10, 20 (default), 30, 40, 50, 60.
+account.1.ptime =
+
+
+#######################################################################################
+##                            Anonymous Call                                         ##
+#######################################################################################
+account.1.anonymous_call = 0
+account.1.anonymous_call_oncode =
+account.1.anonymous_call_offcode =
+
+account.1.reject_anonymous_call =
+account.1.anonymous_reject_oncode =
+account.1.anonymous_reject_offcode =
+
+#######################################################################################
+##                            Pickup Code                                            ##
+#######################################################################################
+account.1.dialoginfo_callpickup = 0
+
+#Configure the directed and group pickup codes for account 1, the settings on a per-account basis take precedence over the settings on the phone.
+account.1.group_pickup_code =
+account.1.direct_pickup_code =
+
+#######################################################################################
+##                            DTMF                                                   ##
+#######################################################################################
+#Configure the DTMF type; 0-INBAND, 1-RFC2833 (default), 2-SIP INFO, 3-AUTO+SIP INFO;
+account.1.dtmf.type =
+
+#Configure the DTMF info type when using the SIP INFO; 0-Disabled (default), 1-DTMF-Relay, 2-DTMF, 3-Telephone-Event;
+account.1.dtmf.info_type =
+
+#Configure the RFC2833 payload. It ranges from 96 to 255, the default value is 101.
+account.1.dtmf.dtmf_payload =
+
+#######################################################################################
+##                            Alert info                                             ##
+#######################################################################################
+#Enable or disable to use the Distinctive Ring Tones; 0-Disabled , 1-Enabled(default);
+account.1.alert_info_url_enable =
+
+#Assign a ringtone for account1. The system ring tones are: common (default), Ring1.wav - Ring8.wav.
+#If you set the custom ring tone (Busy.wav) for the phone, the value is: account.1.ringtone.ring_type = Config:Busy.wav
+#If you set the system ring tone (Ring2.wav) for the phone, the value is: account.1.ringtone.ring_type = Resource:Ring2.wav
+account.1.ringtone.ring_type =
+
+account.1.picture_info_enable = 1
+
+#######################################################################################
+##                            Conference                                             ##
+#######################################################################################
+#Configure the conference type; 0-Local (default), 2-Network Conference;
+account.1.conf_type =
+
+#Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
+account.1.conf_uri =
+
+#######################################################################################
+##                            cid_source                                             ##
+#######################################################################################
+#Configure the type of SIP header(s) to carry the caller ID; 0-FROM (default), 1-PAI 2-PAI-FROM, 3-PRID-PAI-FROM, 4-PAI-RPID-FROM, 5-RPID-FROM;
+account.1.cid_source = {$yealink_cid_source}
+
+account.1.cid_source_privacy = 1
+account.1.cid_source_ppi = 1
+
+#Configure the presentation of the callee ID; 0-PAI-PRID, 1-DIALED DIGITS (default), 2-RFC4916;
+account.1.cp_source = 2
+
+#######################################################################################
+##                            Session Timer                                          ##
+#######################################################################################
+#Enable or disable the session timer, 0-Disabled (default), 1-Enabled;
 account.1.session_timer.enable = {$yealink_session_timer}
 
-account.1.conf_type=
-account.1.sip_server_type=
+#Configure the refresh session timer interval (in seconds). It ranges from 1 to 9999.
+account.1.session_timer.expires =
 
-
-################################################################
-#                        SIP Backup Server                    ##
-################################################################
-
-account.1.outbound_proxy.1.register_on_enable=
-account.1.outbound_proxy.1.failback_timeout=
-account.1.outbound_proxy.1.failback_mode=
-account.1.outbound_proxy.1.retry_counts=
-account.1.outbound_proxy.1.only_signal_with_registered=
-account.1.outbound_proxy.1.failback_subscribe.enable=
-account.1.outbound_proxy.1.invite_retry_counts=
-
-account.1.sip_server.1.register_on_enable= 0
-account.1.sip_server.1.failback_timeout= 3600
-account.1.sip_server.1.failback_mode= 0
-account.1.sip_server.1.failback_subscribe.enable= 
-account.1.sip_server.1.only_signal_with_registered=
-account.1.sip_server.1.invite_retry_counts=
-
-account.1.outbound_proxy.2.register_on_enable=
-account.1.outbound_proxy.2.failback_timeout=
-account.1.outbound_proxy.2.failback_mode=
-account.1.outbound_proxy.2.retry_counts=
-account.1.outbound_proxy.2.only_signal_with_registered=
-account.1.outbound_proxy.2.failback_subscribe.enable=
-account.1.outbound_proxy.2.invite_retry_counts=
-
-account.1.sip_server.2.register_on_enable=
-account.1.sip_server.2.failback_timeout=
-account.1.sip_server.2.failback_mode=
-account.1.sip_server.2.failback_subscribe.enable=
-account.1.sip_server.2.only_signal_with_registered=
-account.1.sip_server.2.invite_retry_counts=
-
-account.1.static_cache_pri=
-account.1.dns_cache_type=
-account.1.naptr_build=
-account.1.fallback.timeout = {$yealink_outbound_proxy_fallback_interval}
-account.1.fallback.redundancy_type=
-account.1.reg_failed_retry_max_time=
-account.1.reg_failed_retry_min_time=
-account.1.redundancy_with_reg_fail.enable =
-
-
-################################################################
-#                        SIP Basic config                     ##
-################################################################
-account.1.contact_take_line_param.enable=
-account.1.update_ack_while_dialing=
-account.1.srtp_lifetime=
-account.1.third_part_request_with_route.enable=
-account.1.insert_outbound_in_route.enable=
-account.1.path.enable=
-account.1.rereg_with_auth.enable=
-account.1.sub_fail_retry_interval=
-account.1.transfer_refer_to_contact_header.enable=
-account.1.hold_use_inactive=
-account.1.gruu.enable=
-account.1.dial_tone=
-account.1.call_id_mode=
-account.1.subscribe_expires_overlap=
-account.1.register_expires_overlap=
-account.1.call_info=
-account.1.custom_ua=
-account.1.mwi_parse_terminated=
-account.1.check_cseq.enable=
-account.1.check_to_tag.enable=
-account.1.vq_rtcpxr.collector_server_port=
-account.1.vq_rtcpxr.collector_server_host=
-account.1.vq_rtcpxr.collector_name=
-account.1.compact_header_enable=
-account.1.cp_source=
-account.1.cid_source_ppi=
-account.1.cid_source_privacy=
-
-account.1.alert_info=
-account.1.picture_info_enable=
-
+#Configure the session timer refresher; 0-Uac (default), 1-Uas;
+account.1.session_timer.refresher =
 
 #######################################################################################
-##                                 History                                           ##       
+##                            Music on Hold                                          ##
 #######################################################################################
-account.1.missed_calllog=
+#Configure the type of Music on Hold; 0-Send the INVITE request to Music on Hold Server then hold the call; 1-Hold the call then send the INVITE request to Music on Hold Server;
+#Require reboot;
+account.1.music_on_hold_type =
 
-
-#######################################################################################  
-##                                  Forward                                          ##  
-####################################################################################### 
-account.1.timeout_fwd.off_code=
-account.1.timeout_fwd.on_code=
-account.1.timeout_fwd.timeout=
-account.1.timeout_fwd.target=
-account.1.timeout_fwd.enable=
-account.1.busy_fwd.off_code=
-account.1.busy_fwd.on_code=
-account.1.busy_fwd.target=
-account.1.busy_fwd.enable=
-account.1.always_fwd.off_code=
-account.1.always_fwd.on_code=
-account.1.always_fwd.target=
-account.1.always_fwd.enable=
-
-
-#######################################################################################  
-##                                  DND                                              ##  
-#######################################################################################
-account.1.dnd.enable=
-account.1.dnd.off_code=
-account.1.dnd.on_code=
-
-
-
-#######################################################################################  
-##                               Voice Mail                                          ##  
-#######################################################################################
-voice_mail.number.1= {$voicemail_number}
-account.1.subscribe_mwi=
-account.1.subscribe_mwi_to_vm=
-account.1.subscribe_mwi_expires=
-account.1.display_mwi.enable=
-
-#######################################################################################  
-##                               Auto Dial                                           ##  
-#######################################################################################
-account.1.auto_dial_enable=
-account.1.auto_dial_num=
-
+account.1.music_server_uri =
 
 #######################################################################################
-##                           Preference&Status                                       ##       
+##                            Advanced                                               ##
 #######################################################################################
-account.1.ringtone.ring_type=
+#Enable or disable the auto answer feature; 0-Disabled (default), 1-Enabled;
+account.1.auto_answer =
+
+#Enable or disable the phone to record the missed call; 0-Disabled, 1-Enabled (default);
+account.1.missed_calllog =
+
+#Enable or disable the 100 reliable retransmission; 0-Disabled (default), 1-Enabled;
+account.1.100rel_enable = {$yealink_retransmission}
+
+#Enable or disable the "user=phone"; 0-Disabled (default), 1-Enabled;
+account.1.enable_user_equal_phone =
+
+#Enable or disable the simplified header field feature; 0-Disabled, 1-Enabled (default);
+account.1.compact_header_enable =
 
 #######################################################################################
-##                           Digitmap                                                ##       
+##                                   DND                                             ##
 #######################################################################################
-account.1.dialplan.digitmap.enable=
-account.1.dialplan.digitmap.string=
-account.1.dialplan.digitmap.no_match_action=
-account.1.dialplan.digitmap.interdigit_short_timer=
-account.1.dialplan.digitmap.interdigit_long_timer=
-account.1.dialplan.digitmap.apply_to.press_send=
-account.1.dialplan.digitmap.apply_to.forward=
-account.1.dialplan.digitmap.apply_to.history_dial=
-account.1.dialplan.digitmap.apply_to.directory_dial=
-account.1.dialplan.digitmap.apply_to.on_hook_dial=
-account.1.dialplan.digitmap.active.on_hook_dialing=
-
+account.1.dnd.enable =
+account.1.dnd.on_code =
+account.1.dnd.off_code =
 
 #######################################################################################
-##                                 Rings Settings                                    ##
+##                                 Call Forward                                      ##
 #######################################################################################
-account.1.alert_info_url_enable=
 
+account.1.always_fwd.enable =
+account.1.always_fwd.target =
+account.1.always_fwd.off_code =
+account.1.always_fwd.on_code =
 
-#######################################################################################
-##                                  BLF/BLF List                                     ##       
-#######################################################################################
-account.1.blf.blf_list_uri=
-account.1.blf_list_barge_in_code=
-account.1.blf_list_code=
-account.1.blf_list_retrieve_call_parked_code=
-account.1.blf.subscribe_period=
-account.1.blf.match_host.enable=
-account.1.out_dialog_blf_enable=
-account.1.blf.subscribe_event=
+account.1.busy_fwd.enable =
+account.1.busy_fwd.target =
+account.1.busy_fwd.off_code =
+account.1.busy_fwd.on_code =
 
-#######################################################################################
-##                                   SCA                                             ##       
-#######################################################################################
-account.1.shared_line = {$shared_line_1}
-account.1.line_seize.expires=
-account.1.shared_line_one_touch_bargein.enable=
-account.1.shared_line_one_touch_retrieve.enable=
-account.1.sca_manage_interface_display_time=
-account.1.shared_line_callpull_code=
+#Enable or disable the no answer forward feature for account1; 0-Disabled (default), 1-Enabled;
+#Configure the waiting ring times before forwarding. It ranges from 0 to 20, the default value is 2.
+account.1.timeout_fwd.enable =
+account.1.timeout_fwd.target =
+account.1.timeout_fwd.timeout =
+account.1.timeout_fwd.off_code =
+account.1.timeout_fwd.on_code =
 
 #######################################################################################
-##                                   BLA                                             ##       
+##                                 Broadsoft Hoteling                                ##
 #######################################################################################
-account.1.bla_number=
-account.1.bla_subscribe_period=
-account.1.bla.notify_with_expire.enable=
-account.1.bla.subscribe_uri_build_type=
+account.1.hoteling.enable = 0
+account.1.hoteling.user_id = 0
+account.1.hoteling.password = 0
+account.1.hoteling.auto_login_enable = 0
 
 #######################################################################################
-##                                   Call Park                                       ##       
+##                                 Broadsoft ACD                                     ##
 #######################################################################################
-account.1.callpark_enable=
-
-
-#######################################################################################
-##                                    Broadsoft ACD                                  ##       
-#######################################################################################
-account.1.acd.enable=
-account.1.acd.available=
-account.1.acd.unavailable_reason_enable=
-account.1.acd.initial_state=
-account.1.subscribe_acd_expires=
-
+account.1.acd.enable = 0
+account.1.acd.unavailable_reason_enable = 0
+account.1.acd.available = 0
+account.1.acd.initial_state = 1
 
 #######################################################################################
-##                                 Broadsoft ACD Call Center                         ##       
+##                                 Broadsoft ACD Call Center                         ##
 #######################################################################################
-##account.X.reason_code.Y=
-##account.X.reason_code_name.Y=
-##account.X.bw_disp_code.Y=
-##account.X.bw_disp_code_name.Y=
-##account.X.supervisor_info_code.Y=
-##account.X.supervisor_info_code_name.Y=
-##The value Y must be continuous.
+#Configure the ACD reason code of Broadsoft.(The valus of Y must be consecutive numbers.)
+#account.1.bw_acd_reason_code.Y = 500(lunch time)
+account.1.bw_acd_reason_code.1 =
 
-account.1.reason_code.1=
-account.1.reason_code_name.1=
-account.1.bw_disp_code.1=
-account.1.bw_disp_code_name.1=
-account.1.supervisor_info_code.1=
-account.1.supervisor_info_code_name.1=
+account.1.reason_code.1 =
+account.1.reason_code_name.1 = 0
+account.1.bw_disp_code.1 =
+account.1.bw_disp_code_name.1 =
+account.1.supervisor_info_code.1 =
+account.1.supervisor_info_code_name.1 =
 
 #######################################################################################
-##                                 Broadsoft Call Center                             ##       
+##                                 Broadsoft Call Center                             ##
 #######################################################################################
-account.1.call_center.call_info_enable=
-account.1.call_center.show_call_info_time=
-account.1.call_center.disp_code_enable=
-account.1.call_center.trace_enable=
-account.1.call_center.emergency_enable=
-account.1.call_center.queue_status_enable=
-account.1.call_center.queue_status_light_enable =
-
-
+account.1.call_center.call_info_enable = 0
+account.1.call_center.show_call_info_time = 30
+account.1.call_center.disp_code_enable = 0
+account.1.call_center.trace_enable = 0
+account.1.call_center.emergency_enable = 0
+account.1.call_center.queue_status_enable = 0
+account.1.call_center.queue_status_light_enable = 0
 
 #######################################################################################
-##                         Broadsoft Hoteling                                        ##       
-#######################################################################################
-account.1.hoteling.enable=
-account.1.hoteling.user_id=
-account.1.hoteling.password=
-account.1.hoteling.expires=
-account.1.hoteling.auto_login_enable=
-
-
-#######################################################################################
-##                              Broadsoft XSI                                        ##       
+##                                 Broadsoft XSI                                     ##
 #######################################################################################
 account.1.xsi.user =
 account.1.xsi.password =
@@ -424,69 +484,2520 @@ account.1.xsi.port =
 
 
 #######################################################################################
-##                                Call Pickup                                        ##       
+##                           Account 2 Basic Settings                                ##
 #######################################################################################
-account.1.direct_pickup_code =
-account.1.group_pickup_code =
-account.1.dialoginfo_callpickup =
-account.1.refresh_remote_id.enable =
+## ranges from 1 to 6;
+##account.X.enable =
+{if isset($user_password_2) }
+account.2.enable = 1
+{else}
+account.2.enable = 0
+{/if}
+account.2.label = {$display_name_2}
+account.2.display_name = {$display_name_2}
+account.2.auth_name = {$auth_id_2}
+account.2.password = {$user_password_2}
+account.2.user_name = {$user_id_2}
+account.2.sip_server_host = {$server_address_2}
+account.2.sip_server_port = {$sip_port_2}
+account.2.outbound_host = {$outbound_proxy_2}
+account.2.outbound_port = 5060
+account.2.sip_listen_port = 5060
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS SRV;
+{if $sip_transport_2 == 'udp'}account.2.transport = 0{/if}
+{if $sip_transport_2 == 'tcp'}account.2.transport = 1{/if}
+{if $sip_transport_2 == 'tls'}account.2.transport = 2{/if}
+{if $sip_transport_2 == 'dns srv'}account.2.transport = 3{/if}
+
+account.2.outbound_proxy.1.address = {$outbound_proxy_primary_2}
+account.2.outbound_proxy.2.address = {$outbound_proxy_secondary_2}
+account.2.outbound_proxy_enable = {if isset($outbound_proxy_primary_2)}1{else}0{/if}
+
+#######################################################################################
+##                          Failback                                                 ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.reregister_enable = 0
+
+account.2.reregister_enable = 0
+account.2.retry_counts =
+account.2.failback_mode = 0
+account.2.failback_timeout = 3600
+account.2.naptr_build = 0
+account.2.fallback.redundancy_type = 0
+account.2.fallback.timeout = {$yealink_outbound_proxy_fallback_interval}
+account.2.sip_server.1.address =
+account.2.sip_server.1.port = 5060
+#Configure the register expiry time (in seconds), the default value is 3600.
+account.2.sip_server.1.expires = {$register_expires_2}
+account.2.sip_server.1.retry_counts = 3
+account.2.sip_server.1.failback_mode = 0
+account.2.sip_server.1.failback_timeout = 3600
+account.2.sip_server.1.register_on_enable = 0
+account.2.sip_server.2.address =
+account.2.sip_server.2.port = 5060
+account.2.sip_server.2.expires = 3600
+account.2.sip_server.2.retry_counts = 3
+account.2.sip_server.2.failback_mode = 0
+account.2.sip_server.2.failback_timeout = 3600
+account.2.sip_server.2.register_on_enable = 0
+account.2.dns_cache_type = 1
+
+account.2.dns_cache_a.1.name =
+account.2.dns_cache_a.1.ip =
+account.2.dns_cache_a.1.ttl = 300
+
+account.2.dns_cache_srv.0.name =
+account.2.dns_cache_srv.0.port = 0
+account.2.dns_cache_srv.0.priority = 0
+account.2.dns_cache_srv.0.target =
+account.2.dns_cache_srv.0.weight = 0
+account.2.dns_cache_srv.0.ttl = 300
+account.2.dns_cache_naptr.0.name =
+account.2.dns_cache_naptr.0.flags =
+account.2.dns_cache_naptr.0.order = 0
+account.2.dns_cache_naptr.0.preference = 0
+account.2.dns_cache_naptr.0.replace =
+account.2.dns_cache_naptr.0.service =
+account.2.dns_cache_naptr.0.ttl = 300
+
+account.2.static_cache_pri = 0
+
+#######################################################################################
+##                           Register Advanced                                       ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.sip_server_type =
+
+#Configure the SIP server type; 0-Default (default), 2-BroadSoft, 4-Cosmocom;
+account.2.sip_server_type =
+#Enable or disable the phone to send the account log-off message first and then send account register message when rebooting the phone; 0-Disabled (default), 1-Enabled;
+account.2.unregister_on_reboot =
+
+#Enable or disable the phone to only accept the message from the server; 0-Disabled (default), 1-Enabled;
+account.2.sip_trust_ctrl = 1
+
+#Configure the timeout (in seconds) for DNS query, the value ranges from 1 to 9, the default value is 8.
+account.2.dns_query_timeout=
+
+#Enable or disable the timer to periodically refresh the DNS-SRV query result; 0-Disabled (default), 1-Enabled;
+account.2.srv_ttl_timer_enable =
+account.2.proxy_require =
+
+
+#Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
+account.2.register_mac =
+account.2.register_line =
+
+#Configure the interval (in seconds) the phone retries to register when account1 fails to register. It ranges from 0 to 1800, the default value is 30.
+account.2.reg_fail_retry_interval =
+
+#########################################################################
+##                     NAT Settings                                    ##
+#########################################################################
+
+#Enable or disable the NAT traversal; 0-Disabled (default), 1-STUN;
+account.2.nat.nat_traversal = {if isset($stun_server)}1{else}0{/if}
+
+#Configure the STUN server address.
+account.2.nat.stun_server = {$stun_server}
+
+#Configure the STUN server port, the default value is 3478.
+account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
+
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.2.nat.udp_update_enable = 1
+
+#Specify the keep-alive interval (in seconds), the default value is 30.
+account.2.nat.udp_update_time = 30
+
+#Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
+account.2.nat.rport = {$yealink_rport}
 
 
 #######################################################################################
-##                              Broadsoft Call Recording                             ##       
+##                            Account2 Advance Settings                              ##
 #######################################################################################
-account.1.call_recording.enable=
+## ranges from 1 to 6;
+##account.X.advanced.timer_t1 = 0.5
+##voice_mail.number.X =
 
-#######################################################################################
-##                                Network Conferene                                  ##       
-#######################################################################################
-account.1.conf_uri=
+#Configure the session timer (in seconds), the default value of T1, T2, T3 is 0.5, 4, 5.
+account.2.advanced.timer_t1 = 0.5
+account.2.advanced.timer_t2 = 4
+account.2.advanced.timer_t4 = 5
 
-
-#######################################################################################
-##                              Broadsoft Call Decline                               ##       
-#######################################################################################
-account.1.features.call_decline.enable =
+voice_mail.number.2 = *97
 
 
 #######################################################################################
-##                       Broadsoft Security Classification                           ##       
+##                            Subscribe                                              ##
 #######################################################################################
-account.1.security_classification.enable =
+## ranges from 1 to 6;
+##account.X.subscribe_mwi =
+
+account.2.subscribe_mwi = 1
+account.2.subscribe_mwi_expires = 3600
+
+#Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
+
+account.2.subscribe_acd_expires= 3600
 
 
+#######################################################################################
+##                            BLF List                                               ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.blf.blf_list_uri =
+
+#Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
+account.2.blf.blf_list_uri =
+
+account.2.blf_list_code =
+account.2.blf_list_barge_in_code =
+account.2.blf.subscribe_period = 1800
+
+account.2.blf.subscribe_event =
+account.2.out_dialog_blf_enable = 0
+
 
 #######################################################################################
-##                        Broadsoft Flexible Seating                                 ##       
+##                            BLA/SCA                                                ##
 #######################################################################################
-account.1.flexible_seating.enable=
-account.1.hoteling.pin=
-account.1.hoteling.mode=
+## ranges from 1 to 6;
+##account.X.shared_line =
+
+#Assign account1 as shared line; 0-Disabled (default), 1-Broadsoft SCA, 2-BLA;
+{if isset($shared_line_2) }
+account.2.shared_line = {$shared_line_2}
+{else}
+account.2.shared_line = 0
+{/if}
+
+#Configure BLA number for account1 and the subscribe period (in seconds). It ranges from 60 to 7200, the default value is 300.
+account.2.bla_number =
+account.2.bla_subscribe_period = 300
+
+#######################################################################################
+##                            Audio Codec                                            ##
+#######################################################################################
+#Audio codecs for account1 (Y ranges from 1 to 11).
+#Enable or disable the specified codec; 0-Disabled, 1-Enabled;
+#account.2.codec.Y.enable =
+#The type of the specified codec.
+#account.2.codec.Y.payload_type =
+#The priority of the specified codec. It's available when the codec is enabled.
+#account.2.codec.Y.priority =
+#The payload of the specified codec.
+#account.2.codec.Y.rtpmap =
+
+account.2.codec.1.enable = 1
+account.2.codec.1.payload_type = PCMU
+account.2.codec.1.priority = 2
+account.2.codec.1.rtpmap = 0
+
+account.2.codec.2.enable = 1
+account.2.codec.2.payload_type = PCMA
+account.2.codec.2.priority = 3
+account.2.codec.2.rtpmap = 8
+
+account.2.codec.3.enable = 0
+account.2.codec.3.payload_type = G723_53
+account.2.codec.3.priority =0
+account.2.codec.3.rtpmap = 4
+
+account.2.codec.4.enable = 0
+account.2.codec.4.payload_type = G723_63
+account.2.codec.4.priority = 0
+account.2.codec.4.rtpmap = 4
+
+account.2.codec.5.enable = 1
+account.2.codec.5.payload_type = G729
+account.2.codec.5.priority = 3
+account.2.codec.5.rtpmap = 18
+
+account.2.codec.6.enable = 1
+account.2.codec.6.payload_type = G722
+account.2.codec.6.priority = 1
+account.2.codec.6.rtpmap = 9
+
+account.2.codec.7.enable = 0
+account.2.codec.7.payload_type = iLBC
+account.2.codec.7.priority =  0
+account.2.codec.7.rtpmap = 106
+
+account.2.codec.8.enable = 0
+account.2.codec.8.payload_type = G726-16
+account.2.codec.8.priority = 0
+account.2.codec.8.rtpmap = 103
+
+account.2.codec.9.enable = 0
+account.2.codec.9.payload_type = G726-24
+account.2.codec.9.priority = 0
+account.2.codec.9.rtpmap = 104
+
+account.2.codec.10.enable = 0
+account.2.codec.10.payload_type = G726-32
+account.2.codec.10.priority = 0
+account.2.codec.10.rtpmap = 102
+
+account.2.codec.11.enable = 0
+account.2.codec.11.payload_type = G726-40
+account.2.codec.11.priority = 0
+account.2.codec.11.rtpmap = 105
+
+account.2.codec.12.enable = 0
+account.2.codec.12.payload_type = GSM
+account.2.codec.12.priority = 0
+account.2.codec.12.rtpmap = 3
 
 
 #######################################################################################
-##                         Features Sync                                             ##       
+##                            Audio Advanced                                         ##
 #######################################################################################
-account.1.features.forward.feature_key_sync.local_processing.enable=
-account.1.features.dnd.feature_key_sync.local_processing.enable =
+#Specify whether to encrypt the SIP messages; 0-Disabled (default), 1-Forced, 2-Negotiated;
+account.2.srtp_encryption =
+
+#Configure the RTP packet time. The valid values are 0 (Disabled), 10, 20 (default), 30, 40, 50, 60.
+account.2.ptime =
+
 
 #######################################################################################
-##                                   ACD                                             ##       
+##                            Anonymous Call                                         ##
 #######################################################################################
-account.1.acd.available_url=
-account.1.acd.away_url =
-account.1.acd.refresh_url =
-account.1.acd.call_information=
+account.2.anonymous_call = 0
+account.2.anonymous_call_oncode =
+account.2.anonymous_call_offcode =
 
+account.2.reject_anonymous_call =
+account.2.anonymous_reject_oncode =
+account.2.anonymous_reject_offcode =
+
+#######################################################################################
+##                            Pickup Code                                            ##
+#######################################################################################
+account.2.dialoginfo_callpickup = 0
+
+#Configure the directed and group pickup codes for account 1, the settings on a per-account basis take precedence over the settings on the phone.
+account.2.group_pickup_code =
+account.2.direct_pickup_code =
+
+#######################################################################################
+##                            DTMF                                                   ##
+#######################################################################################
+#Configure the DTMF type; 0-INBAND, 1-RFC2833 (default), 2-SIP INFO, 3-AUTO+SIP INFO;
+account.2.dtmf.type =
+
+#Configure the DTMF info type when using the SIP INFO; 0-Disabled (default), 1-DTMF-Relay, 2-DTMF, 3-Telephone-Event;
+account.2.dtmf.info_type =
+
+#Configure the RFC2833 payload. It ranges from 96 to 255, the default value is 101.
+account.2.dtmf.dtmf_payload =
+
+#######################################################################################
+##                            Alert info                                             ##
+#######################################################################################
+#Enable or disable to use the Distinctive Ring Tones;  0-Disabled , 1-Enabled(default);
+account.2.alert_info_url_enable =
+
+#Assign a ringtone for account2. The system ring tones are: common (default), Ring1.wav - Ring8.wav.
+#If you set the custom ring tone (Busy.wav) for the phone, the value is: account.2.ringtone.ring_type = Config:Busy.wav
+#If you set the system ring tone (Ring2.wav) for the phone, the value is: account.2.ringtone.ring_type = Resource:Ring2.wav
+account.2.ringtone.ring_type =
+
+account.2.picture_info_enable = 1
+
+#######################################################################################
+##                            Conference                                             ##
+#######################################################################################
+#Configure the conference type; 0-Local (default), 2-Network Conference;
+account.2.conf_type =
+
+#Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
+account.2.conf_uri =
+
+#######################################################################################
+##                            cid source                                             ##
+#######################################################################################
+#Configure the type of SIP header(s) to carry the caller ID; 0-FROM (default), 1-PAI 2-PAI-FROM, 3-PRID-PAI-FROM, 4-PAI-RPID-FROM, 5-RPID-FROM;
+account.2.cid_source = {$yealink_cid_source}
+
+account.2.cid_source_privacy = 1
+account.2.cid_source_ppi = 1
+
+#Configure the presentation of the callee ID; 0-PAI-PRID, 1-DIALED DIGITS (default), 2-RFC4916;
+account.2.cp_source = 2
+
+#######################################################################################
+##                            Session Timer                                          ##
+#######################################################################################
+#Enable or disable the session timer, 0-Disabled (default), 1-Enabled;
+account.2.session_timer.enable = {$yealink_session_timer}
+
+#Configure the refresh session timer interval (in seconds). It ranges from 1 to 9999.
+account.2.session_timer.expires =
+
+#Configure the session timer refresher; 0-Uac (default), 1-Uas;
+account.2.session_timer.refresher =
+
+#######################################################################################
+##                            Music on Hold                                          ##
+#######################################################################################
+#Configure the type of Music on Hold; 0-Send the INVITE request to Music on Hold Server then hold the call; 1-Hold the call then send the INVITE request to Music on Hold Server;
+#Require reboot;
+account.2.music_on_hold_type =
+
+account.2.music_server_uri =
+
+#######################################################################################
+##                            Advanced                                               ##
+#######################################################################################
+#Enable or disable the auto answer feature; 0-Disabled (default), 1-Enabled;
+account.2.auto_answer =
+
+#Enable or disable the phone to record the missed call; 0-Disabled, 1-Enabled (default);
+account.2.missed_calllog =
+
+#Enable or disable the 100 reliable retransmission; 0-Disabled (default), 1-Enabled;
+account.2.100rel_enable = {$yealink_retransmission}
+
+#Enable or disable the "user=phone"; 0-Disabled (default), 1-Enabled;
+account.2.enable_user_equal_phone =
+
+#Enable or disable the simplified header field feature; 0-Disabled, 1-Enabled (default);
+account.2.compact_header_enable =
+
+#######################################################################################
+##                                   DND                                             ##
+#######################################################################################
+account.2.dnd.enable =
+account.2.dnd.on_code =
+account.2.dnd.off_code =
+
+#######################################################################################
+##                                 Call Forward                                      ##
+#######################################################################################
+#Enable or disable the busy forward feature for account; 0-Disabled (default), 1-Enabled;
+account.2.always_fwd.enable =
+account.2.always_fwd.target =
+account.2.always_fwd.off_code =
+account.2.always_fwd.on_code =
+
+account.2.busy_fwd.enable =
+account.2.busy_fwd.target =
+account.2.busy_fwd.off_code =
+account.2.busy_fwd.on_code =
+
+#Enable or disable the no answer forward feature for account1; 0-Disabled (default), 1-Enabled;
+#Configure the waiting ring times before forwarding. It ranges from 0 to 20, the default value is 2.
+account.2.timeout_fwd.enable =
+account.2.timeout_fwd.target =
+account.2.timeout_fwd.timeout =
+account.2.timeout_fwd.off_code =
+account.2.timeout_fwd.on_code =
+
+#######################################################################################
+##                                 Broadsoft Hoteling                                ##
+#######################################################################################
+account.2.hoteling.enable = 0
+account.2.hoteling.user_id = 0
+account.2.hoteling.password = 0
+account.2.hoteling.auto_login_enable = 0
+
+#######################################################################################
+##                                 Broadsoft ACD                                     ##
+#######################################################################################
+account.2.acd.enable = 0
+account.2.acd.unavailable_reason_enable = 0
+account.2.acd.available = 0
+account.2.acd.initial_state = 1
+
+#######################################################################################
+##                                 Broadsoft ACD Call Center                         ##
+#######################################################################################
+#Configure the ACD reason code of Broadsoft.(The valus of Y must be consecutive numbers.)
+#account.2.bw_acd_reason_code.Y = 500(lunch time)
+account.2.bw_acd_reason_code.1 =
+
+account.2.reason_code.1 =
+account.2.reason_code_name.1 = 0
+account.2.bw_disp_code.1 =
+account.2.bw_disp_code_name.1 =
+account.2.supervisor_info_code.1 =
+account.2.supervisor_info_code_name.1 =
+
+#######################################################################################
+##                                 Broadsoft Call Center                             ##
+#######################################################################################
+account.2.call_center.call_info_enable = 0
+account.2.call_center.show_call_info_time = 30
+account.2.call_center.disp_code_enable = 0
+account.2.call_center.trace_enable = 0
+account.2.call_center.emergency_enable = 0
+account.2.call_center.queue_status_enable = 0
+account.2.call_center.queue_status_light_enable = 0
+
+#######################################################################################
+##                                 Broadsoft XSI                                     ##
+#######################################################################################
+account.2.xsi.user =
+account.2.xsi.password =
+account.2.xsi.host =
+account.2.xsi.server_type =
+account.2.xsi.port =
+
+
+#######################################################################################
+##                                 Time                                              ##
+#######################################################################################
+#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
+#local_time.time_zone = +8
+#local_time.time_zone_name = China(Beijing)
+local_time.time_zone = {$yealink_time_zone}
+local_time.time_zone_name = {$yealink_time_zone_name}
+
+
+#######################################################################################
+##                                   NETWORK                                         ##
+#######################################################################################
+##0-ipv4, 1-ipv6, 2-ipv4&ipv6
+network.ip_address_mode = 2
+
+network.ipv6_prefix = 64
+network.ipv6_internet_port.type =
+network.ipv6_internet_port.ip =
+network.ipv6_internet_port.gateway =
+network.ipv6_primary_dns =
+network.ipv6_secondary_dns =
+network.ipv6_icmp_v6.enable =
+
+#Configure the WAN port type; 0-DHCP (default), 1-PPPoE, 2-Static IP Address;
+#Require reboot;
+network.internet_port.type =
+
+#Configure the static IP address, subnet mask, gateway and DNS server;
+#Require Reboot;
+network.internet_port.ip =
+network.internet_port.mask =
+network.internet_port.gateway =
+{if isset($dns_server_primary)}
+network.primary_dns = {$dns_server_primary}
+{/if}
+{if isset($dns_server_secondary)}
+network.secondary_dns = {$dns_server_secondary}
+{/if}
+{if isset($dns_server_primary)}
+network.static_dns_enable = 1
+{else}network.static_dns_enable = 0
+{/if}
+
+#######################################################################################
+##                           Account 3 Basic Settings                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.enable =
+{if isset($user_password_3) }
+account.3.enable = 1
+{else}
+account.3.enable = 0
+{/if}
+account.3.label = {$display_name_3}
+account.3.display_name = {$display_name_3}
+account.3.auth_name = {$auth_id_3}
+account.3.password = {$user_password_3}
+account.3.user_name = {$user_id_3}
+account.3.sip_server_host = {$server_address_3}
+account.3.sip_server_port = {$sip_port_3}
+account.3.outbound_host = {$outbound_proxy_3}
+account.3.outbound_port = 5060
+account.3.sip_listen_port = 5060
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS SRV;
+{if $sip_transport_3 == 'udp'}account.3.transport = 0{/if}
+{if $sip_transport_3 == 'tcp'}account.3.transport = 1{/if}
+{if $sip_transport_3 == 'tls'}account.3.transport = 2{/if}
+{if $sip_transport_3 == 'dns srv'}account.3.transport = 3{/if}
+
+account.3.outbound_proxy.1.address = {$outbound_proxy_primary_3}
+account.3.outbound_proxy.2.address = {$outbound_proxy_secondary_3}
+account.3.outbound_proxy_enable = {if isset($outbound_proxy_primary_3)}1{else}0{/if}
+
+#######################################################################################
+##                          Failback                                                 ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.reregister_enable = 0
+
+account.3.reregister_enable = 0
+account.3.retry_counts =
+account.3.failback_mode = 0
+account.3.failback_timeout = 3600
+account.3.naptr_build = 0
+account.3.fallback.redundancy_type = 0
+account.3.fallback.timeout = {$yealink_outbound_proxy_fallback_interval}
+account.3.sip_server.1.address =
+account.3.sip_server.1.port = 5060
+#Configure the register expiry time (in seconds), the default value is 3600.
+account.3.sip_server.1.expires = {$register_expires_3}
+account.3.sip_server.1.retry_counts = 3
+account.3.sip_server.1.failback_mode = 0
+account.3.sip_server.1.failback_timeout = 3600
+account.3.sip_server.1.register_on_enable = 0
+account.3.sip_server.2.address =
+account.3.sip_server.2.port = 5060
+account.3.sip_server.2.expires = 3600
+account.3.sip_server.2.retry_counts = 3
+account.3.sip_server.2.failback_mode = 0
+account.3.sip_server.2.failback_timeout = 3600
+account.3.sip_server.2.register_on_enable = 0
+account.3.dns_cache_type = 1
+
+account.3.dns_cache_a.1.name =
+account.3.dns_cache_a.1.ip =
+account.3.dns_cache_a.1.ttl = 300
+
+account.3.dns_cache_srv.0.name =
+account.3.dns_cache_srv.0.port = 0
+account.3.dns_cache_srv.0.priority = 0
+account.3.dns_cache_srv.0.target =
+account.3.dns_cache_srv.0.weight = 0
+account.3.dns_cache_srv.0.ttl = 300
+account.3.dns_cache_naptr.0.name =
+account.3.dns_cache_naptr.0.flags =
+account.3.dns_cache_naptr.0.order = 0
+account.3.dns_cache_naptr.0.preference = 0
+account.3.dns_cache_naptr.0.replace =
+account.3.dns_cache_naptr.0.service =
+account.3.dns_cache_naptr.0.ttl = 300
+
+account.3.static_cache_pri = 0
+
+#######################################################################################
+##                           Register Advanced                                       ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.sip_server_type =
+
+#Configure the SIP server type; 0-Default (default), 2-BroadSoft, 4-Cosmocom;
+account.3.sip_server_type =
+#Enable or disable the phone to send the account log-off message first and then send account register message when rebooting the phone; 0-Disabled (default), 1-Enabled;
+account.3.unregister_on_reboot =
+
+#Enable or disable the phone to only accept the message from the server; 0-Disabled (default), 1-Enabled;
+account.3.sip_trust_ctrl = 1
+
+#Configure the timeout (in seconds) for DNS query, the value ranges from 1 to 9, the default value is 8.
+account.3.dns_query_timeout=
+
+#Enable or disable the timer to periodically refresh the DNS-SRV query result; 0-Disabled (default), 1-Enabled;
+account.3.srv_ttl_timer_enable =
+account.3.proxy_require =
+
+
+#Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
+account.3.register_mac =
+account.3.register_line =
+
+#Configure the interval (in seconds) the phone retries to register when account1 fails to register. It ranges from 0 to 1800, the default value is 30.
+account.3.reg_fail_retry_interval =
+
+#########################################################################
+##                     NAT Settings                                    ##
+#########################################################################
+
+#Enable or disable the NAT traversal; 0-Disabled (default), 1-STUN;
+account.3.nat.nat_traversal = {if isset($stun_server)}1{else}0{/if}
+
+#Configure the STUN server address.
+account.3.nat.stun_server = {$stun_server}
+
+#Configure the STUN server port, the default value is 3478.
+account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
+
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.3.nat.udp_update_enable = 1
+
+#Specify the keep-alive interval (in seconds), the default value is 30.
+account.3.nat.udp_update_time = 30
+
+#Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
+account.3.nat.rport = {$yealink_rport}
+
+
+#######################################################################################
+##                            Account3 Advance Settings                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.advanced.timer_t1 = 0.5
+##voice_mail.number.X =
+
+#Configure the session timer (in seconds), the default value of T1, T2, T3 is 0.5, 4, 5.
+account.3.advanced.timer_t1 = 0.5
+account.3.advanced.timer_t2 = 4
+account.3.advanced.timer_t4 = 5
+
+voice_mail.number.3 = *97
+
+
+#######################################################################################
+##                            Subscribe                                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.subscribe_mwi =
+
+account.3.subscribe_mwi = 1
+account.3.subscribe_mwi_expires = 3600
+
+#Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
+
+account.3.subscribe_acd_expires= 3600
+
+
+#######################################################################################
+##                            BLF List                                               ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.blf.blf_list_uri =
+
+#Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
+account.3.blf.blf_list_uri =
+
+account.3.blf_list_code =
+account.3.blf_list_barge_in_code =
+account.3.blf.subscribe_period = 1800
+
+account.3.blf.subscribe_event =
+account.3.out_dialog_blf_enable = 0
+
+
+#######################################################################################
+##                            BLA/SCA                                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.shared_line =
+
+#Assign account1 as shared line; 0-Disabled (default), 1-Broadsoft SCA, 2-BLA;
+{if isset($shared_line_3) }
+account.3.shared_line = {$shared_line_3}
+{else}
+account.3.shared_line = 0
+{/if}
+
+#Configure BLA number for account1 and the subscribe period (in seconds). It ranges from 60 to 7200, the default value is 300.
+account.3.bla_number =
+account.3.bla_subscribe_period = 300
+
+#######################################################################################
+##                            Audio Codec                                            ##
+#######################################################################################
+#Audio codecs for account1 (Y ranges from 1 to 11).
+#Enable or disable the specified codec; 0-Disabled, 1-Enabled;
+#account.3.codec.Y.enable =
+#The type of the specified codec.
+#account.3.codec.Y.payload_type =
+#The priority of the specified codec. It's available when the codec is enabled.
+#account.3.codec.Y.priority =
+#The payload of the specified codec.
+#account.3.codec.Y.rtpmap =
+
+account.3.codec.1.enable = 1
+account.3.codec.1.payload_type = PCMU
+account.3.codec.1.priority = 2
+account.3.codec.1.rtpmap = 0
+
+account.3.codec.2.enable = 1
+account.3.codec.2.payload_type = PCMA
+account.3.codec.2.priority = 3
+account.3.codec.2.rtpmap = 8
+
+account.3.codec.3.enable = 0
+account.3.codec.3.payload_type = G723_53
+account.3.codec.3.priority =0
+account.3.codec.3.rtpmap = 4
+
+account.3.codec.4.enable = 0
+account.3.codec.4.payload_type = G723_63
+account.3.codec.4.priority = 0
+account.3.codec.4.rtpmap = 4
+
+account.3.codec.5.enable = 1
+account.3.codec.5.payload_type = G729
+account.3.codec.5.priority = 3
+account.3.codec.5.rtpmap = 18
+
+account.3.codec.6.enable = 1
+account.3.codec.6.payload_type = G722
+account.3.codec.6.priority = 1
+account.3.codec.6.rtpmap = 9
+
+account.3.codec.7.enable = 0
+account.3.codec.7.payload_type = iLBC
+account.3.codec.7.priority =  0
+account.3.codec.7.rtpmap = 106
+
+account.3.codec.8.enable = 0
+account.3.codec.8.payload_type = G726-16
+account.3.codec.8.priority = 0
+account.3.codec.8.rtpmap = 103
+
+account.3.codec.9.enable = 0
+account.3.codec.9.payload_type = G726-24
+account.3.codec.9.priority = 0
+account.3.codec.9.rtpmap = 104
+
+account.3.codec.10.enable = 0
+account.3.codec.10.payload_type = G726-32
+account.3.codec.10.priority = 0
+account.3.codec.10.rtpmap = 102
+
+account.3.codec.11.enable = 0
+account.3.codec.11.payload_type = G726-40
+account.3.codec.11.priority = 0
+account.3.codec.11.rtpmap = 105
+
+account.3.codec.12.enable = 0
+account.3.codec.12.payload_type = GSM
+account.3.codec.12.priority = 0
+account.3.codec.12.rtpmap = 3
+
+
+#######################################################################################
+##                            Audio Advanced                                         ##
+#######################################################################################
+#Specify whether to encrypt the SIP messages; 0-Disabled (default), 1-Forced, 2-Negotiated;
+account.3.srtp_encryption =
+
+#Configure the RTP packet time. The valid values are 0 (Disabled), 10, 20 (default), 30, 40, 50, 60.
+account.3.ptime =
+
+
+#######################################################################################
+##                            Anonymous Call                                         ##
+#######################################################################################
+account.3.anonymous_call = 0
+account.3.anonymous_call_oncode =
+account.3.anonymous_call_offcode =
+
+account.3.reject_anonymous_call =
+account.3.anonymous_reject_oncode =
+account.3.anonymous_reject_offcode =
+
+#######################################################################################
+##                            Pickup Code                                            ##
+#######################################################################################
+account.3.dialoginfo_callpickup = 0
+
+#Configure the directed and group pickup codes for account 1, the settings on a per-account basis take precedence over the settings on the phone.
+account.3.group_pickup_code =
+account.3.direct_pickup_code =
+
+#######################################################################################
+##                            DTMF                                                   ##
+#######################################################################################
+#Configure the DTMF type; 0-INBAND, 1-RFC2833 (default), 2-SIP INFO, 3-AUTO+SIP INFO;
+account.3.dtmf.type =
+
+#Configure the DTMF info type when using the SIP INFO; 0-Disabled (default), 1-DTMF-Relay, 2-DTMF, 3-Telephone-Event;
+account.3.dtmf.info_type =
+
+#Configure the RFC2833 payload. It ranges from 96 to 255, the default value is 101.
+account.3.dtmf.dtmf_payload =
+
+#######################################################################################
+##                            Alert info                                             ##
+#######################################################################################
+#Enable or disable to use the Distinctive Ring Tones;  0-Disabled , 1-Enabled(default);
+account.3.alert_info_url_enable =
+
+#Assign a ringtone for account2. The system ring tones are: common (default), Ring1.wav - Ring8.wav.
+#If you set the custom ring tone (Busy.wav) for the phone, the value is: account.2.ringtone.ring_type = Config:Busy.wav
+#If you set the system ring tone (Ring2.wav) for the phone, the value is: account.2.ringtone.ring_type = Resource:Ring2.wav
+account.3.ringtone.ring_type =
+
+account.3.picture_info_enable = 1
+
+#######################################################################################
+##                            Conference                                             ##
+#######################################################################################
+#Configure the conference type; 0-Local (default), 2-Network Conference;
+account.3.conf_type =
+
+#Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
+account.3.conf_uri =
+
+#######################################################################################
+##                            cid source                                             ##
+#######################################################################################
+#Configure the type of SIP header(s) to carry the caller ID; 0-FROM (default), 1-PAI 2-PAI-FROM, 3-PRID-PAI-FROM, 4-PAI-RPID-FROM, 5-RPID-FROM;
+account.3.cid_source = {$yealink_cid_source}
+
+account.3.cid_source_privacy = 1
+account.3.cid_source_ppi = 1
+
+#Configure the presentation of the callee ID; 0-PAI-PRID, 1-DIALED DIGITS (default), 2-RFC4916;
+account.3.cp_source = 2
+
+#######################################################################################
+##                            Session Timer                                          ##
+#######################################################################################
+#Enable or disable the session timer, 0-Disabled (default), 1-Enabled;
+account.3.session_timer.enable = {$yealink_session_timer}
+
+#Configure the refresh session timer interval (in seconds). It ranges from 1 to 9999.
+account.3.session_timer.expires =
+
+#Configure the session timer refresher; 0-Uac (default), 1-Uas;
+account.3.session_timer.refresher =
+
+#######################################################################################
+##                            Music on Hold                                          ##
+#######################################################################################
+#Configure the type of Music on Hold; 0-Send the INVITE request to Music on Hold Server then hold the call; 1-Hold the call then send the INVITE request to Music on Hold Server;
+#Require reboot;
+account.3.music_on_hold_type =
+
+account.3.music_server_uri =
+
+#######################################################################################
+##                            Advanced                                               ##
+#######################################################################################
+#Enable or disable the auto answer feature; 0-Disabled (default), 1-Enabled;
+account.3.auto_answer =
+
+#Enable or disable the phone to record the missed call; 0-Disabled, 1-Enabled (default);
+account.3.missed_calllog =
+
+#Enable or disable the 100 reliable retransmission; 0-Disabled (default), 1-Enabled;
+account.3.100rel_enable = {$yealink_retransmission}
+
+#Enable or disable the "user=phone"; 0-Disabled (default), 1-Enabled;
+account.3.enable_user_equal_phone =
+
+#Enable or disable the simplified header field feature; 0-Disabled, 1-Enabled (default);
+account.3.compact_header_enable =
+
+#######################################################################################
+##                                   DND                                             ##
+#######################################################################################
+account.3.dnd.enable =
+account.3.dnd.on_code =
+account.3.dnd.off_code =
+
+#######################################################################################
+##                                 Call Forward                                      ##
+#######################################################################################
+#Enable or disable the busy forward feature for account; 0-Disabled (default), 1-Enabled;
+account.3.always_fwd.enable =
+account.3.always_fwd.target =
+account.3.always_fwd.off_code =
+account.3.always_fwd.on_code =
+
+account.3.busy_fwd.enable =
+account.3.busy_fwd.target =
+account.3.busy_fwd.off_code =
+account.3.busy_fwd.on_code =
+
+#Enable or disable the no answer forward feature for account1; 0-Disabled (default), 1-Enabled;
+#Configure the waiting ring times before forwarding. It ranges from 0 to 20, the default value is 2.
+account.3.timeout_fwd.enable =
+account.3.timeout_fwd.target =
+account.3.timeout_fwd.timeout =
+account.3.timeout_fwd.off_code =
+account.3.timeout_fwd.on_code =
+
+#######################################################################################
+##                                 Broadsoft Hoteling                                ##
+#######################################################################################
+account.3.hoteling.enable = 0
+account.3.hoteling.user_id = 0
+account.3.hoteling.password = 0
+account.3.hoteling.auto_login_enable = 0
+
+#######################################################################################
+##                                 Broadsoft ACD                                     ##
+#######################################################################################
+account.3.acd.enable = 0
+account.3.acd.unavailable_reason_enable = 0
+account.3.acd.available = 0
+account.3.acd.initial_state = 1
+
+#######################################################################################
+##                                 Broadsoft ACD Call Center                         ##
+#######################################################################################
+#Configure the ACD reason code of Broadsoft.(The valus of Y must be consecutive numbers.)
+#account.3.bw_acd_reason_code.Y = 500(lunch time)
+account.3.bw_acd_reason_code.1 =
+
+account.3.reason_code.1 =
+account.3.reason_code_name.1 = 0
+account.3.bw_disp_code.1 =
+account.3.bw_disp_code_name.1 =
+account.3.supervisor_info_code.1 =
+account.3.supervisor_info_code_name.1 =
+
+#######################################################################################
+##                                 Broadsoft Call Center                             ##
+#######################################################################################
+account.3.call_center.call_info_enable = 0
+account.3.call_center.show_call_info_time = 30
+account.3.call_center.disp_code_enable = 0
+account.3.call_center.trace_enable = 0
+account.3.call_center.emergency_enable = 0
+account.3.call_center.queue_status_enable = 0
+account.3.call_center.queue_status_light_enable = 0
+
+#######################################################################################
+##                                 Broadsoft XSI                                     ##
+#######################################################################################
+account.3.xsi.user =
+account.3.xsi.password =
+account.3.xsi.host =
+account.3.xsi.server_type =
+account.3.xsi.port =
+
+
+#######################################################################################
+##                                   NETWORK                                         ##
+#######################################################################################
+##0-ipv4, 1-ipv6, 2-ipv4&ipv6
+network.ip_address_mode = 2
+
+network.ipv6_prefix = 64
+network.ipv6_internet_port.type =
+network.ipv6_internet_port.ip =
+network.ipv6_internet_port.gateway =
+network.ipv6_primary_dns =
+network.ipv6_secondary_dns =
+network.ipv6_icmp_v6.enable =
+
+#Configure the WAN port type; 0-DHCP (default), 1-PPPoE, 2-Static IP Address;
+#Require reboot;
+network.internet_port.type =
+
+#Configure the static IP address, subnet mask, gateway and DNS server;
+#Require Reboot;
+network.internet_port.ip =
+network.internet_port.mask =
+network.internet_port.gateway =
+{if isset($dns_server_primary)}network.primary_dns = {$dns_server_primary}{/if}
+{if isset($dns_server_secondary)}network.secondary_dns = {$dns_server_secondary}{/if}
+
+#######################################################################################
+##                           Account 4 Basic Settings                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.enable =
+{if isset($user_password_4) }
+account.4.enable = 1
+{else}
+account.4.enable = 0
+{/if}
+account.4.label = {$display_name_4}
+account.4.display_name = {$display_name_4}
+account.4.auth_name = {$auth_id_4}
+account.4.password = {$user_password_4}
+account.4.user_name = {$user_id_4}
+account.4.sip_server_host = {$server_address_4}
+account.4.sip_server_port = {$sip_port_4}
+account.4.outbound_host = {$outbound_proxy_4}
+account.4.outbound_port = 5060
+account.4.sip_listen_port = 5060
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS SRV;
+{if $sip_transport_4 == 'udp'}account.4.transport = 0{/if}
+{if $sip_transport_4 == 'tcp'}account.4.transport = 1{/if}
+{if $sip_transport_4 == 'tls'}account.4.transport = 2{/if}
+{if $sip_transport_4 == 'dns srv'}account.4.transport = 3{/if}
+
+account.4.outbound_proxy.1.address = {$outbound_proxy_primary_4}
+account.4.outbound_proxy.2.address = {$outbound_proxy_secondary_4}
+account.4.outbound_proxy_enable = {if isset($outbound_proxy_primary_4)}1{else}0{/if}
+
+#######################################################################################
+##                          Failback                                                 ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.reregister_enable = 0
+
+account.4.reregister_enable = 0
+account.4.retry_counts =
+account.4.failback_mode = 0
+account.4.failback_timeout = 3600
+account.4.naptr_build = 0
+account.4.fallback.redundancy_type = 0
+account.4.fallback.timeout = {$yealink_outbound_proxy_fallback_interval}
+account.4.sip_server.1.address =
+account.4.sip_server.1.port = 5060
+#Configure the register expiry time (in seconds), the default value is 3600.
+account.4.sip_server.1.expires = {$register_expires_4}
+account.4.sip_server.1.retry_counts = 3
+account.4.sip_server.1.failback_mode = 0
+account.4.sip_server.1.failback_timeout = 3600
+account.4.sip_server.1.register_on_enable = 0
+account.4.sip_server.2.address =
+account.4.sip_server.2.port = 5060
+account.4.sip_server.2.expires = 3600
+account.4.sip_server.2.retry_counts = 3
+account.4.sip_server.2.failback_mode = 0
+account.4.sip_server.2.failback_timeout = 3600
+account.4.sip_server.2.register_on_enable = 0
+account.4.dns_cache_type = 1
+
+account.4.dns_cache_a.1.name =
+account.4.dns_cache_a.1.ip =
+account.4.dns_cache_a.1.ttl = 300
+
+account.4.dns_cache_srv.1.name =
+account.4.dns_cache_srv.1.port = 0
+account.4.dns_cache_srv.1.priority = 0
+account.4.dns_cache_srv.1.target =
+account.4.dns_cache_srv.1.weight = 0
+account.4.dns_cache_srv.1.ttl = 300
+account.4.dns_cache_naptr.1.name =
+account.4.dns_cache_naptr.1.flags =
+account.4.dns_cache_naptr.1.order = 0
+account.4.dns_cache_naptr.1.preference = 0
+account.4.dns_cache_naptr.1.replace =
+account.4.dns_cache_naptr.1.service =
+account.4.dns_cache_naptr.1.ttl = 300
+
+account.4.static_cache_pri = 0
+
+#######################################################################################
+##                           Register Advanced                                       ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.sip_server_type =
+
+#Configure the SIP server type; 0-Default (default), 2-BroadSoft, 4-Cosmocom;
+account.4.sip_server_type =
+#Enable or disable the phone to send the account log-off message first and then send account register message when rebooting the phone; 0-Disabled (default), 1-Enabled;
+account.4.unregister_on_reboot =
+
+#Enable or disable the phone to only accept the message from the server; 0-Disabled (default), 1-Enabled;
+account.4.sip_trust_ctrl = 1
+
+#Configure the timeout (in seconds) for DNS query, the value ranges from 1 to 9, the default value is 8.
+account.4.dns_query_timeout=
+
+#Enable or disable the timer to periodically refresh the DNS-SRV query result; 0-Disabled (default), 1-Enabled;
+account.4.srv_ttl_timer_enable =
+account.4.proxy_require =
+
+
+#Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
+account.4.register_mac =
+account.4.register_line =
+
+#Configure the interval (in seconds) the phone retries to register when account1 fails to register. It ranges from 0 to 1800, the default value is 30.
+account.4.reg_fail_retry_interval =
+
+#########################################################################
+##                     NAT Settings                                    ##
+#########################################################################
+
+#Enable or disable the NAT traversal; 0-Disabled (default), 1-STUN;
+account.4.nat.nat_traversal = {if isset($stun_server)}1{else}0{/if}
+
+#Configure the STUN server address.
+account.4.nat.stun_server = {$stun_server}
+
+#Configure the STUN server port, the default value is 3478.
+account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
+
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.4.nat.udp_update_enable = 1
+
+#Specify the keep-alive interval (in seconds), the default value is 30.
+account.4.nat.udp_update_time = 30
+
+#Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
+account.4.nat.rport = {$yealink_rport}
+
+
+#######################################################################################
+##                            Account4 Advance Settings                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.advanced.timer_t1 = 0.5
+##voice_mail.number.X =
+
+#Configure the session timer (in seconds), the default value of T1, T2, T3 is 0.5, 4, 5.
+account.4.advanced.timer_t1 = 0.5
+account.4.advanced.timer_t2 = 4
+account.4.advanced.timer_t4 = 5
+
+voice_mail.number.4 = *97
+
+
+#######################################################################################
+##                            Subscribe                                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.subscribe_mwi =
+
+account.4.subscribe_mwi = 1
+account.4.subscribe_mwi_expires = 3600
+
+#Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
+
+account.4.subscribe_acd_expires= 3600
+
+
+#######################################################################################
+##                            BLF List                                               ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.blf.blf_list_uri =
+
+#Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
+account.4.blf.blf_list_uri =
+
+account.4.blf_list_code =
+account.4.blf_list_barge_in_code =
+account.4.blf.subscribe_period = 1800
+
+account.4.blf.subscribe_event =
+account.4.out_dialog_blf_enable = 0
+
+
+#######################################################################################
+##                            BLA/SCA                                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.shared_line =
+
+#Assign account1 as shared line; 0-Disabled (default), 1-Broadsoft SCA, 2-BLA;
+{if isset($shared_line_4) }
+account.4.shared_line = {$shared_line_4}
+{else}
+account.4.shared_line = 0
+{/if}
+
+#Configure BLA number for account1 and the subscribe period (in seconds). It ranges from 60 to 7200, the default value is 300.
+account.4.bla_number =
+account.4.bla_subscribe_period = 300
+
+#######################################################################################
+##                            Audio Codec                                            ##
+#######################################################################################
+#Audio codecs for account1 (Y ranges from 1 to 11).
+#Enable or disable the specified codec; 0-Disabled, 1-Enabled;
+#account.4.codec.Y.enable =
+#The type of the specified codec.
+#account.4.codec.Y.payload_type =
+#The priority of the specified codec. It's available when the codec is enabled.
+#account.4.codec.Y.priority =
+#The payload of the specified codec.
+#account.4.codec.Y.rtpmap =
+
+account.4.codec.1.enable = 1
+account.4.codec.1.payload_type = PCMU
+account.4.codec.1.priority = 1
+account.4.codec.1.rtpmap = 0
+
+account.4.codec.2.enable = 1
+account.4.codec.2.payload_type = PCMA
+account.4.codec.2.priority = 2
+account.4.codec.2.rtpmap = 8
+
+account.4.codec.3.enable = 0
+account.4.codec.3.payload_type = G723_53
+account.4.codec.3.priority =0
+account.4.codec.3.rtpmap = 4
+
+account.4.codec.4.enable = 0
+account.4.codec.4.payload_type = G723_63
+account.4.codec.4.priority = 0
+account.4.codec.4.rtpmap = 4
+
+account.4.codec.5.enable = 1
+account.4.codec.5.payload_type = G729
+account.4.codec.5.priority = 3
+account.4.codec.5.rtpmap = 18
+
+account.4.codec.6.enable = 1
+account.4.codec.6.payload_type = G722
+account.4.codec.6.priority = 4
+account.4.codec.6.rtpmap = 9
+
+account.4.codec.7.enable = 0
+account.4.codec.7.payload_type = iLBC
+account.4.codec.7.priority =  0
+account.4.codec.7.rtpmap = 106
+
+account.4.codec.8.enable = 0
+account.4.codec.8.payload_type = G726-16
+account.4.codec.8.priority = 0
+account.4.codec.8.rtpmap = 103
+
+account.4.codec.9.enable = 0
+account.4.codec.9.payload_type = G726-24
+account.4.codec.9.priority = 0
+account.4.codec.9.rtpmap = 104
+
+account.4.codec.10.enable = 0
+account.4.codec.10.payload_type = G726-32
+account.4.codec.10.priority = 0
+account.4.codec.10.rtpmap = 102
+
+account.4.codec.11.enable = 0
+account.4.codec.11.payload_type = G726-40
+account.4.codec.11.priority = 0
+account.4.codec.11.rtpmap = 105
+
+account.4.codec.12.enable = 0
+account.4.codec.12.payload_type = GSM
+account.4.codec.12.priority = 0
+account.4.codec.12.rtpmap = 3
+
+
+#######################################################################################
+##                            Audio Advanced                                         ##
+#######################################################################################
+#Specify whether to encrypt the SIP messages; 0-Disabled (default), 1-Forced, 2-Negotiated;
+account.4.srtp_encryption =
+
+#Configure the RTP packet time. The valid values are 0 (Disabled), 10, 20 (default), 30, 40, 50, 60.
+account.4.ptime =
+
+
+#######################################################################################
+##                            Anonymous Call                                         ##
+#######################################################################################
+account.4.anonymous_call = 0
+account.4.anonymous_call_oncode =
+account.4.anonymous_call_offcode =
+
+account.4.reject_anonymous_call =
+account.4.anonymous_reject_oncode =
+account.4.anonymous_reject_offcode =
+
+#######################################################################################
+##                            Pickup Code                                            ##
+#######################################################################################
+account.4.dialoginfo_callpickup = 0
+
+#Configure the directed and group pickup codes for account 1, the settings on a per-account basis take precedence over the settings on the phone.
+account.4.group_pickup_code =
+account.4.direct_pickup_code =
+
+#######################################################################################
+##                            DTMF                                                   ##
+#######################################################################################
+#Configure the DTMF type; 0-INBAND, 1-RFC2833 (default), 2-SIP INFO, 3-AUTO+SIP INFO;
+account.4.dtmf.type =
+
+#Configure the DTMF info type when using the SIP INFO; 0-Disabled (default), 1-DTMF-Relay, 2-DTMF, 3-Telephone-Event;
+account.4.dtmf.info_type =
+
+#Configure the RFC2833 payload. It ranges from 96 to 255, the default value is 101.
+account.4.dtmf.dtmf_payload =
+
+#######################################################################################
+##                            Alert info                                             ##
+#######################################################################################
+#Enable or disable to use the Distinctive Ring Tones;  0-Disabled , 1-Enabled(default);
+account.4.alert_info_url_enable =
+
+#Assign a ringtone for account2. The system ring tones are: common (default), Ring1.wav - Ring8.wav.
+#If you set the custom ring tone (Busy.wav) for the phone, the value is: account.2.ringtone.ring_type = Config:Busy.wav
+#If you set the system ring tone (Ring2.wav) for the phone, the value is: account.2.ringtone.ring_type = Resource:Ring2.wav
+account.4.ringtone.ring_type =
+
+account.4.picture_info_enable = 1
+
+#######################################################################################
+##                            Conference                                             ##
+#######################################################################################
+#Configure the conference type; 0-Local (default), 2-Network Conference;
+account.4.conf_type =
+
+#Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
+account.4.conf_uri =
+
+#######################################################################################
+##                            cid source                                             ##
+#######################################################################################
+#Configure the type of SIP header(s) to carry the caller ID; 0-FROM (default), 1-PAI 2-PAI-FROM, 3-PRID-PAI-FROM, 4-PAI-RPID-FROM, 5-RPID-FROM;
+account.4.cid_source = {$yealink_cid_source}
+
+account.4.cid_source_privacy = 1
+account.4.cid_source_ppi = 1
+
+#Configure the presentation of the callee ID; 0-PAI-PRID, 1-DIALED DIGITS (default), 2-RFC4916;
+account.4.cp_source = 2
+
+#######################################################################################
+##                            Session Timer                                          ##
+#######################################################################################
+#Enable or disable the session timer, 0-Disabled (default), 1-Enabled;
+account.4.session_timer.enable = {$yealink_session_timer}
+
+#Configure the refresh session timer interval (in seconds). It ranges from 1 to 9999.
+account.4.session_timer.expires =
+
+#Configure the session timer refresher; 0-Uac (default), 1-Uas;
+account.4.session_timer.refresher =
+
+#######################################################################################
+##                            Music on Hold                                          ##
+#######################################################################################
+#Configure the type of Music on Hold; 0-Send the INVITE request to Music on Hold Server then hold the call; 1-Hold the call then send the INVITE request to Music on Hold Server;
+#Require reboot;
+account.4.music_on_hold_type =
+
+account.4.music_server_uri =
+
+#######################################################################################
+##                            Advanced                                               ##
+#######################################################################################
+#Enable or disable the auto answer feature; 0-Disabled (default), 1-Enabled;
+account.4.auto_answer =
+
+#Enable or disable the phone to record the missed call; 0-Disabled, 1-Enabled (default);
+account.4.missed_calllog =
+
+#Enable or disable the 100 reliable retransmission; 0-Disabled (default), 1-Enabled;
+account.4.100rel_enable = {$yealink_retransmission}
+
+#Enable or disable the "user=phone"; 0-Disabled (default), 1-Enabled;
+account.4.enable_user_equal_phone =
+
+#Enable or disable the simplified header field feature; 0-Disabled, 1-Enabled (default);
+account.4.compact_header_enable =
+
+#######################################################################################
+##                                   DND                                             ##
+#######################################################################################
+account.4.dnd.enable =
+account.4.dnd.on_code =
+account.4.dnd.off_code =
+
+#######################################################################################
+##                                 Call Forward                                      ##
+#######################################################################################
+#Enable or disable the busy forward feature for account; 0-Disabled (default), 1-Enabled;
+account.4.always_fwd.enable =
+account.4.always_fwd.target =
+account.4.always_fwd.off_code =
+account.4.always_fwd.on_code =
+
+account.4.busy_fwd.enable =
+account.4.busy_fwd.target =
+account.4.busy_fwd.off_code =
+account.4.busy_fwd.on_code =
+
+#Enable or disable the no answer forward feature for account1; 0-Disabled (default), 1-Enabled;
+#Configure the waiting ring times before forwarding. It ranges from 0 to 20, the default value is 2.
+account.4.timeout_fwd.enable =
+account.4.timeout_fwd.target =
+account.4.timeout_fwd.timeout =
+account.4.timeout_fwd.off_code =
+account.4.timeout_fwd.on_code =
+
+#######################################################################################
+##                                 Broadsoft Hoteling                                ##
+#######################################################################################
+account.4.hoteling.enable = 0
+account.4.hoteling.user_id = 0
+account.4.hoteling.password = 0
+account.4.hoteling.auto_login_enable = 0
+
+#######################################################################################
+##                                 Broadsoft ACD                                     ##
+#######################################################################################
+account.4.acd.enable = 0
+account.4.acd.unavailable_reason_enable = 0
+account.4.acd.available = 0
+account.4.acd.initial_state = 1
+
+#######################################################################################
+##                                 Broadsoft ACD Call Center                         ##
+#######################################################################################
+#Configure the ACD reason code of Broadsoft.(The valus of Y must be consecutive numbers.)
+#account.4.bw_acd_reason_code.Y = 500(lunch time)
+account.4.bw_acd_reason_code.1 =
+
+account.4.reason_code.1 =
+account.4.reason_code_name.1 = 0
+account.4.bw_disp_code.1 =
+account.4.bw_disp_code_name.1 =
+account.4.supervisor_info_code.1 =
+account.4.supervisor_info_code_name.1 =
+
+#######################################################################################
+##                                 Broadsoft Call Center                             ##
+#######################################################################################
+account.4.call_center.call_info_enable = 0
+account.4.call_center.show_call_info_time = 30
+account.4.call_center.disp_code_enable = 0
+account.4.call_center.trace_enable = 0
+account.4.call_center.emergency_enable = 0
+account.4.call_center.queue_status_enable = 0
+account.4.call_center.queue_status_light_enable = 0
+
+#######################################################################################
+##                                 Broadsoft XSI                                     ##
+#######################################################################################
+account.4.xsi.user =
+account.4.xsi.password =
+account.4.xsi.host =
+account.4.xsi.server_type =
+account.4.xsi.port =
+
+
+#######################################################################################
+##                                   NETWORK                                         ##
+#######################################################################################
+##0-ipv4, 1-ipv6, 2-ipv4&ipv6
+network.ip_address_mode = 2
+
+network.ipv6_prefix = 64
+network.ipv6_internet_port.type =
+network.ipv6_internet_port.ip =
+network.ipv6_internet_port.gateway =
+network.ipv6_primary_dns =
+network.ipv6_secondary_dns =
+network.ipv6_icmp_v6.enable =
+
+#Configure the WAN port type; 0-DHCP (default), 1-PPPoE, 2-Static IP Address;
+#Require reboot;
+network.internet_port.type =
+
+#Configure the static IP address, subnet mask, gateway and DNS server;
+#Require Reboot;
+network.internet_port.ip =
+network.internet_port.mask =
+network.internet_port.gateway =
+{if isset($dns_server_primary)}network.primary_dns = {$dns_server_primary}{/if}
+{if isset($dns_server_secondary)}network.secondary_dns = {$dns_server_secondary}{/if}
+
+#######################################################################################
+##                           Account 5 Basic Settings                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.enable =
+{if isset($user_password_5) }
+account.5.enable = 1
+{else}
+account.5.enable = 0
+{/if}
+account.5.label = {$display_name_5}
+account.5.display_name = {$display_name_5}
+account.5.auth_name = {$auth_id_5}
+account.5.password = {$user_password_5}
+account.5.user_name = {$user_id_5}
+account.5.sip_server_host = {$server_address_5}
+account.5.sip_server_port = {$sip_port_5}
+account.5.outbound_host = {$outbound_proxy_5}
+account.5.outbound_port = 5060
+account.5.sip_listen_port = 5060
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS SRV;
+{if $sip_transport_5 == 'udp'}account.5.transport = 0{/if}
+{if $sip_transport_5 == 'tcp'}account.5.transport = 1{/if}
+{if $sip_transport_5 == 'tls'}account.5.transport = 2{/if}
+{if $sip_transport_5 == 'dns srv'}account.5.transport = 3{/if}
+
+account.5.outbound_proxy.1.address = {$outbound_proxy_primary_5}
+account.5.outbound_proxy.2.address = {$outbound_proxy_secondary_5}
+account.5.outbound_proxy_enable = {if isset($outbound_proxy_primary_5)}1{else}0{/if}
+
+#######################################################################################
+##                          Failback                                                 ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.reregister_enable = 0
+
+account.5.reregister_enable = 0
+account.5.retry_counts =
+account.5.failback_mode = 0
+account.5.failback_timeout = 3600
+account.5.naptr_build = 0
+account.5.fallback.redundancy_type = 0
+account.5.fallback.timeout = {$yealink_outbound_proxy_fallback_interval}
+account.5.sip_server.1.address =
+account.5.sip_server.1.port = 5060
+#Configure the register expiry time (in seconds), the default value is 3600.
+account.5.sip_server.1.expires = {$register_expires_5}
+account.5.sip_server.1.retry_counts = 3
+account.5.sip_server.1.failback_mode = 0
+account.5.sip_server.1.failback_timeout = 3600
+account.5.sip_server.1.register_on_enable = 0
+account.5.sip_server.2.address =
+account.5.sip_server.2.port = 5060
+account.5.sip_server.2.expires = 3600
+account.5.sip_server.2.retry_counts = 3
+account.5.sip_server.2.failback_mode = 0
+account.5.sip_server.2.failback_timeout = 3600
+account.5.sip_server.2.register_on_enable = 0
+account.5.dns_cache_type = 1
+
+account.5.dns_cache_a.1.name =
+account.5.dns_cache_a.1.ip =
+account.5.dns_cache_a.1.ttl = 300
+
+account.5.dns_cache_srv.1.name =
+account.5.dns_cache_srv.1.port = 0
+account.5.dns_cache_srv.1.priority = 0
+account.5.dns_cache_srv.1.target =
+account.5.dns_cache_srv.1.weight = 0
+account.5.dns_cache_srv.1.ttl = 300
+account.5.dns_cache_naptr.1.name =
+account.5.dns_cache_naptr.1.flags =
+account.5.dns_cache_naptr.1.order = 0
+account.5.dns_cache_naptr.1.preference = 0
+account.5.dns_cache_naptr.1.replace =
+account.5.dns_cache_naptr.1.service =
+account.5.dns_cache_naptr.1.ttl = 300
+
+account.5.static_cache_pri = 0
+
+#######################################################################################
+##                           Register Advanced                                       ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.sip_server_type =
+
+#Configure the SIP server type; 0-Default (default), 2-BroadSoft, 4-Cosmocom;
+account.5.sip_server_type =
+#Enable or disable the phone to send the account log-off message first and then send account register message when rebooting the phone; 0-Disabled (default), 1-Enabled;
+account.5.unregister_on_reboot =
+
+#Enable or disable the phone to only accept the message from the server; 0-Disabled (default), 1-Enabled;
+account.5.sip_trust_ctrl = 1
+
+#Configure the timeout (in seconds) for DNS query, the value ranges from 1 to 9, the default value is 8.
+account.5.dns_query_timeout=
+
+#Enable or disable the timer to periodically refresh the DNS-SRV query result; 0-Disabled (default), 1-Enabled;
+account.5.srv_ttl_timer_enable =
+account.5.proxy_require =
+
+
+#Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
+account.5.register_mac =
+account.5.register_line =
+
+#Configure the interval (in seconds) the phone retries to register when account1 fails to register. It ranges from 0 to 1800, the default value is 30.
+account.5.reg_fail_retry_interval =
+
+#########################################################################
+##                     NAT Settings                                    ##
+#########################################################################
+
+#Enable or disable the NAT traversal; 0-Disabled (default), 1-STUN;
+account.5.nat.nat_traversal = {if isset($stun_server)}1{else}0{/if}
+
+#Configure the STUN server address.
+account.5.nat.stun_server = {$stun_server}
+
+#Configure the STUN server port, the default value is 3478.
+account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
+
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.5.nat.udp_update_enable = 1
+
+#Specify the keep-alive interval (in seconds), the default value is 30.
+account.5.nat.udp_update_time = 30
+
+#Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
+account.5.nat.rport = {$yealink_rport}
+
+
+#######################################################################################
+##                            Account5 Advance Settings                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.advanced.timer_t1 = 0.5
+##voice_mail.number.X =
+
+#Configure the session timer (in seconds), the default value of T1, T2, T3 is 0.5, 4, 5.
+account.5.advanced.timer_t1 = 0.5
+account.5.advanced.timer_t2 = 4
+account.5.advanced.timer_t4 = 5
+
+voice_mail.number.5 = *97
+
+
+#######################################################################################
+##                            Subscribe                                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.subscribe_mwi =
+
+account.5.subscribe_mwi = 1
+account.5.subscribe_mwi_expires = 3600
+
+#Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
+
+account.5.subscribe_acd_expires= 3600
+
+
+#######################################################################################
+##                            BLF List                                               ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.blf.blf_list_uri =
+
+#Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
+account.5.blf.blf_list_uri =
+
+account.5.blf_list_code =
+account.5.blf_list_barge_in_code =
+account.5.blf.subscribe_period = 1800
+
+account.5.blf.subscribe_event =
+account.5.out_dialog_blf_enable = 0
+
+
+#######################################################################################
+##                            BLA/SCA                                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.shared_line =
+
+#Assign account1 as shared line; 0-Disabled (default), 1-Broadsoft SCA, 2-BLA;
+{if isset($shared_line_5) }
+account.5.shared_line = {$shared_line_5}
+{else}
+account.5.shared_line = 0
+{/if}
+
+#Configure BLA number for account1 and the subscribe period (in seconds). It ranges from 60 to 7200, the default value is 300.
+account.5.bla_number =
+account.5.bla_subscribe_period = 300
+
+#######################################################################################
+##                            Audio Codec                                            ##
+#######################################################################################
+#Audio codecs for account1 (Y ranges from 1 to 11).
+#Enable or disable the specified codec; 0-Disabled, 1-Enabled;
+#account.5.codec.Y.enable =
+#The type of the specified codec.
+#account.5.codec.Y.payload_type =
+#The priority of the specified codec. It's available when the codec is enabled.
+#account.5.codec.Y.priority =
+#The payload of the specified codec.
+#account.5.codec.Y.rtpmap =
+
+account.5.codec.1.enable = 1
+account.5.codec.1.payload_type = PCMU
+account.5.codec.1.priority = 1
+account.5.codec.1.rtpmap = 0
+
+account.5.codec.2.enable = 1
+account.5.codec.2.payload_type = PCMA
+account.5.codec.2.priority = 2
+account.5.codec.2.rtpmap = 8
+
+account.5.codec.3.enable = 0
+account.5.codec.3.payload_type = G723_53
+account.5.codec.3.priority =0
+account.5.codec.3.rtpmap = 4
+
+account.5.codec.4.enable = 0
+account.5.codec.4.payload_type = G723_63
+account.5.codec.4.priority = 0
+account.5.codec.4.rtpmap = 4
+
+account.5.codec.5.enable = 1
+account.5.codec.5.payload_type = G729
+account.5.codec.5.priority = 3
+account.5.codec.5.rtpmap = 18
+
+account.5.codec.6.enable = 1
+account.5.codec.6.payload_type = G722
+account.5.codec.6.priority = 4
+account.5.codec.6.rtpmap = 9
+
+account.5.codec.7.enable = 0
+account.5.codec.7.payload_type = iLBC
+account.5.codec.7.priority =  0
+account.5.codec.7.rtpmap = 106
+
+account.5.codec.8.enable = 0
+account.5.codec.8.payload_type = G726-16
+account.5.codec.8.priority = 0
+account.5.codec.8.rtpmap = 103
+
+account.5.codec.9.enable = 0
+account.5.codec.9.payload_type = G726-24
+account.5.codec.9.priority = 0
+account.5.codec.9.rtpmap = 104
+
+account.5.codec.10.enable = 0
+account.5.codec.10.payload_type = G726-32
+account.5.codec.10.priority = 0
+account.5.codec.10.rtpmap = 102
+
+account.5.codec.11.enable = 0
+account.5.codec.11.payload_type = G726-40
+account.5.codec.11.priority = 0
+account.5.codec.11.rtpmap = 105
+
+account.5.codec.12.enable = 0
+account.5.codec.12.payload_type = GSM
+account.5.codec.12.priority = 0
+account.5.codec.12.rtpmap = 3
+
+
+#######################################################################################
+##                            Audio Advanced                                         ##
+#######################################################################################
+#Specify whether to encrypt the SIP messages; 0-Disabled (default), 1-Forced, 2-Negotiated;
+account.5.srtp_encryption =
+
+#Configure the RTP packet time. The valid values are 0 (Disabled), 10, 20 (default), 30, 40, 50, 60.
+account.5.ptime =
+
+
+#######################################################################################
+##                            Anonymous Call                                         ##
+#######################################################################################
+account.5.anonymous_call = 0
+account.5.anonymous_call_oncode =
+account.5.anonymous_call_offcode =
+
+account.5.reject_anonymous_call =
+account.5.anonymous_reject_oncode =
+account.5.anonymous_reject_offcode =
+
+#######################################################################################
+##                            Pickup Code                                            ##
+#######################################################################################
+account.5.dialoginfo_callpickup = 0
+
+#Configure the directed and group pickup codes for account 1, the settings on a per-account basis take precedence over the settings on the phone.
+account.5.group_pickup_code =
+account.5.direct_pickup_code =
+
+#######################################################################################
+##                            DTMF                                                   ##
+#######################################################################################
+#Configure the DTMF type; 0-INBAND, 1-RFC2833 (default), 2-SIP INFO, 3-AUTO+SIP INFO;
+account.5.dtmf.type =
+
+#Configure the DTMF info type when using the SIP INFO; 0-Disabled (default), 1-DTMF-Relay, 2-DTMF, 3-Telephone-Event;
+account.5.dtmf.info_type =
+
+#Configure the RFC2833 payload. It ranges from 96 to 255, the default value is 101.
+account.5.dtmf.dtmf_payload =
+
+#######################################################################################
+##                            Alert info                                             ##
+#######################################################################################
+#Enable or disable to use the Distinctive Ring Tones;  0-Disabled , 1-Enabled(default);
+account.5.alert_info_url_enable =
+
+#Assign a ringtone for account2. The system ring tones are: common (default), Ring1.wav - Ring8.wav.
+#If you set the custom ring tone (Busy.wav) for the phone, the value is: account.2.ringtone.ring_type = Config:Busy.wav
+#If you set the system ring tone (Ring2.wav) for the phone, the value is: account.2.ringtone.ring_type = Resource:Ring2.wav
+account.5.ringtone.ring_type =
+
+account.5.picture_info_enable = 1
+
+#######################################################################################
+##                            Conference                                             ##
+#######################################################################################
+#Configure the conference type; 0-Local (default), 2-Network Conference;
+account.5.conf_type =
+
+#Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
+account.5.conf_uri =
+
+#######################################################################################
+##                            cid source                                             ##
+#######################################################################################
+#Configure the type of SIP header(s) to carry the caller ID; 0-FROM (default), 1-PAI 2-PAI-FROM, 3-PRID-PAI-FROM, 4-PAI-RPID-FROM, 5-RPID-FROM;
+account.5.cid_source = {$yealink_cid_source}
+
+account.5.cid_source_privacy = 1
+account.5.cid_source_ppi = 1
+
+#Configure the presentation of the callee ID; 0-PAI-PRID, 1-DIALED DIGITS (default), 2-RFC4916;
+account.5.cp_source = 2
+
+#######################################################################################
+##                            Session Timer                                          ##
+#######################################################################################
+#Enable or disable the session timer, 0-Disabled (default), 1-Enabled;
+account.5.session_timer.enable = {$yealink_session_timer}
+
+#Configure the refresh session timer interval (in seconds). It ranges from 1 to 9999.
+account.5.session_timer.expires =
+
+#Configure the session timer refresher; 0-Uac (default), 1-Uas;
+account.5.session_timer.refresher =
+
+#######################################################################################
+##                            Music on Hold                                          ##
+#######################################################################################
+#Configure the type of Music on Hold; 0-Send the INVITE request to Music on Hold Server then hold the call; 1-Hold the call then send the INVITE request to Music on Hold Server;
+#Require reboot;
+account.5.music_on_hold_type =
+
+account.5.music_server_uri =
+
+#######################################################################################
+##                            Advanced                                               ##
+#######################################################################################
+#Enable or disable the auto answer feature; 0-Disabled (default), 1-Enabled;
+account.5.auto_answer =
+
+#Enable or disable the phone to record the missed call; 0-Disabled, 1-Enabled (default);
+account.5.missed_calllog =
+
+#Enable or disable the 100 reliable retransmission; 0-Disabled (default), 1-Enabled;
+account.5.100rel_enable = {$yealink_retransmission}
+
+#Enable or disable the "user=phone"; 0-Disabled (default), 1-Enabled;
+account.5.enable_user_equal_phone =
+
+#Enable or disable the simplified header field feature; 0-Disabled, 1-Enabled (default);
+account.5.compact_header_enable =
+
+#######################################################################################
+##                                   DND                                             ##
+#######################################################################################
+account.5.dnd.enable =
+account.5.dnd.on_code =
+account.5.dnd.off_code =
+
+#######################################################################################
+##                                 Call Forward                                      ##
+#######################################################################################
+#Enable or disable the busy forward feature for account; 0-Disabled (default), 1-Enabled;
+account.5.always_fwd.enable =
+account.5.always_fwd.target =
+account.5.always_fwd.off_code =
+account.5.always_fwd.on_code =
+
+account.5.busy_fwd.enable =
+account.5.busy_fwd.target =
+account.5.busy_fwd.off_code =
+account.5.busy_fwd.on_code =
+
+#Enable or disable the no answer forward feature for account1; 0-Disabled (default), 1-Enabled;
+#Configure the waiting ring times before forwarding. It ranges from 0 to 20, the default value is 2.
+account.5.timeout_fwd.enable =
+account.5.timeout_fwd.target =
+account.5.timeout_fwd.timeout =
+account.5.timeout_fwd.off_code =
+account.5.timeout_fwd.on_code =
+
+#######################################################################################
+##                                 Broadsoft Hoteling                                ##
+#######################################################################################
+account.5.hoteling.enable = 0
+account.5.hoteling.user_id = 0
+account.5.hoteling.password = 0
+account.5.hoteling.auto_login_enable = 0
+
+#######################################################################################
+##                                 Broadsoft ACD                                     ##
+#######################################################################################
+account.5.acd.enable = 0
+account.5.acd.unavailable_reason_enable = 0
+account.5.acd.available = 0
+account.5.acd.initial_state = 1
+
+#######################################################################################
+##                                 Broadsoft ACD Call Center                         ##
+#######################################################################################
+#Configure the ACD reason code of Broadsoft.(The valus of Y must be consecutive numbers.)
+#account.5.bw_acd_reason_code.Y = 500(lunch time)
+account.5.bw_acd_reason_code.1 =
+
+account.5.reason_code.1 =
+account.5.reason_code_name.1 = 0
+account.5.bw_disp_code.1 =
+account.5.bw_disp_code_name.1 =
+account.5.supervisor_info_code.1 =
+account.5.supervisor_info_code_name.1 =
+
+#######################################################################################
+##                                 Broadsoft Call Center                             ##
+#######################################################################################
+account.5.call_center.call_info_enable = 0
+account.5.call_center.show_call_info_time = 30
+account.5.call_center.disp_code_enable = 0
+account.5.call_center.trace_enable = 0
+account.5.call_center.emergency_enable = 0
+account.5.call_center.queue_status_enable = 0
+account.5.call_center.queue_status_light_enable = 0
+
+#######################################################################################
+##                                 Broadsoft XSI                                     ##
+#######################################################################################
+account.5.xsi.user =
+account.5.xsi.password =
+account.5.xsi.host =
+account.5.xsi.server_type =
+account.5.xsi.port =
+
+
+#######################################################################################
+##                                   NETWORK                                         ##
+#######################################################################################
+##0-ipv4, 1-ipv6, 2-ipv4&ipv6
+network.ip_address_mode = 2
+
+network.ipv6_prefix = 64
+network.ipv6_internet_port.type =
+network.ipv6_internet_port.ip =
+network.ipv6_internet_port.gateway =
+network.ipv6_primary_dns =
+network.ipv6_secondary_dns =
+network.ipv6_icmp_v6.enable =
+
+#Configure the WAN port type; 0-DHCP (default), 1-PPPoE, 2-Static IP Address;
+#Require reboot;
+network.internet_port.type =
+
+#Configure the static IP address, subnet mask, gateway and DNS server;
+#Require Reboot;
+network.internet_port.ip =
+network.internet_port.mask =
+network.internet_port.gateway =
+{if isset($dns_server_primary)}network.primary_dns = {$dns_server_primary}{/if}
+{if isset($dns_server_secondary)}network.secondary_dns = {$dns_server_secondary}{/if}
+
+#######################################################################################
+##                           Account 6 Basic Settings                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.enable =
+{if isset($user_password_6) }
+account.6.enable = 1
+{else}
+account.6.enable = 0
+{/if}
+account.6.label = {$display_name_6}
+account.6.display_name = {$display_name_6}
+account.6.auth_name = {$auth_id_6}
+account.6.password = {$user_password_6}
+account.6.user_name = {$user_id_6}
+account.6.sip_server_host = {$server_address_6}
+account.6.sip_server_port = {$sip_port_6}
+account.6.outbound_host = {$outbound_proxy_6}
+account.6.outbound_port = 5060
+account.6.sip_listen_port = 5060
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS SRV;
+{if $sip_transport_6 == 'udp'}account.6.transport = 0{/if}
+{if $sip_transport_6 == 'tcp'}account.6.transport = 1{/if}
+{if $sip_transport_6 == 'tls'}account.6.transport = 2{/if}
+{if $sip_transport_6 == 'dns srv'}account.6.transport = 3{/if}
+
+account.6.outbound_proxy.1.address = {$outbound_proxy_primary_6}
+account.6.outbound_proxy.2.address = {$outbound_proxy_secondary_6}
+account.6.outbound_proxy_enable = {if isset($outbound_proxy_primary_6)}1{else}0{/if}
+
+#######################################################################################
+##                          Failback                                                 ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.reregister_enable = 0
+
+account.6.reregister_enable = 0
+account.6.retry_counts =
+account.6.failback_mode = 0
+account.6.failback_timeout = 3600
+account.6.naptr_build = 0
+account.6.fallback.redundancy_type = 0
+account.6.fallback.timeout = {$yealink_outbound_proxy_fallback_interval}
+account.6.sip_server.1.address =
+account.6.sip_server.1.port = 5060
+#Configure the register expiry time (in seconds), the default value is 3600.
+account.6.sip_server.1.expires = {$register_expires_6}
+account.6.sip_server.1.retry_counts = 3
+account.6.sip_server.1.failback_mode = 0
+account.6.sip_server.1.failback_timeout = 3600
+account.6.sip_server.1.register_on_enable = 0
+account.6.sip_server.2.address =
+account.6.sip_server.2.port = 5060
+account.6.sip_server.2.expires = 3600
+account.6.sip_server.2.retry_counts = 3
+account.6.sip_server.2.failback_mode = 0
+account.6.sip_server.2.failback_timeout = 3600
+account.6.sip_server.2.register_on_enable = 0
+account.6.dns_cache_type = 1
+
+account.6.dns_cache_a.1.name =
+account.6.dns_cache_a.1.ip =
+account.6.dns_cache_a.1.ttl = 300
+
+account.6.dns_cache_srv.1.name =
+account.6.dns_cache_srv.1.port = 0
+account.6.dns_cache_srv.1.priority = 0
+account.6.dns_cache_srv.1.target =
+account.6.dns_cache_srv.1.weight = 0
+account.6.dns_cache_srv.1.ttl = 300
+account.6.dns_cache_naptr.1.name =
+account.6.dns_cache_naptr.1.flags =
+account.6.dns_cache_naptr.1.order = 0
+account.6.dns_cache_naptr.1.preference = 0
+account.6.dns_cache_naptr.1.replace =
+account.6.dns_cache_naptr.1.service =
+account.6.dns_cache_naptr.1.ttl = 300
+
+account.6.static_cache_pri = 0
+
+#######################################################################################
+##                           Register Advanced                                       ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.sip_server_type =
+
+#Configure the SIP server type; 0-Default (default), 2-BroadSoft, 4-Cosmocom;
+account.6.sip_server_type =
+#Enable or disable the phone to send the account log-off message first and then send account register message when rebooting the phone; 0-Disabled (default), 1-Enabled;
+account.6.unregister_on_reboot =
+
+#Enable or disable the phone to only accept the message from the server; 0-Disabled (default), 1-Enabled;
+account.6.sip_trust_ctrl = 1
+
+#Configure the timeout (in seconds) for DNS query, the value ranges from 1 to 9, the default value is 8.
+account.6.dns_query_timeout=
+
+#Enable or disable the timer to periodically refresh the DNS-SRV query result; 0-Disabled (default), 1-Enabled;
+account.6.srv_ttl_timer_enable =
+account.6.proxy_require =
+
+
+#Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
+account.6.register_mac =
+account.6.register_line =
+
+#Configure the interval (in seconds) the phone retries to register when account1 fails to register. It ranges from 0 to 1800, the default value is 30.
+account.6.reg_fail_retry_interval =
+
+#########################################################################
+##                     NAT Settings                                    ##
+#########################################################################
+## ranges from 1 to 6;
+##account.X.nat.nat_traversal = 0
+
+#Enable or disable the NAT traversal; 0-Disabled (default), 1-STUN;
+account.6.nat.nat_traversal = 0
+
+account.6.nat.stun_server =
+account.6.nat.stun_port = 3478
+
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.6.nat.udp_update_enable = 1
+
+#Specify the keep-alive interval (in seconds), the default value is 30.
+account.6.nat.udp_update_time = 30
+
+#Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
+account.6.nat.rport = {$yealink_rport}
+
+
+#######################################################################################
+##                            Account6 Advance Settings                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.advanced.timer_t1 = 0.5
+##voice_mail.number.X =
+
+#Configure the session timer (in seconds), the default value of T1, T2, T3 is 0.5, 4, 5.
+account.6.advanced.timer_t1 = 0.5
+account.6.advanced.timer_t2 = 4
+account.6.advanced.timer_t4 = 5
+
+voice_mail.number.6 = *97
+
+
+#######################################################################################
+##                            Subscribe                                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.subscribe_mwi =
+
+account.6.subscribe_mwi = 0
+account.6.subscribe_mwi_expires = 3600
+
+#Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
+
+account.6.subscribe_acd_expires= 3600
+
+
+#######################################################################################
+##                            BLF List                                               ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.blf.blf_list_uri =
+
+#Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
+account.6.blf.blf_list_uri =
+
+account.6.blf_list_code =
+account.6.blf_list_barge_in_code =
+account.6.blf.subscribe_period = 1800
+
+account.6.blf.subscribe_event =
+account.6.out_dialog_blf_enable = 0
+
+
+#######################################################################################
+##                            BLA/SCA                                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.shared_line =
+
+#Assign account1 as shared line; 0-Disabled (default), 1-Broadsoft SCA, 2-BLA;
+{if isset($shared_line_6) }
+account.6.shared_line = {$shared_line_6}
+{else}
+account.6.shared_line = 0
+{/if}
+
+#Configure BLA number for account1 and the subscribe period (in seconds). It ranges from 60 to 7200, the default value is 300.
+account.6.bla_number =
+account.6.bla_subscribe_period = 300
+
+#######################################################################################
+##                            Audio Codec                                            ##
+#######################################################################################
+#Audio codecs for account1 (Y ranges from 1 to 11).
+#Enable or disable the specified codec; 0-Disabled, 1-Enabled;
+#account.6.codec.Y.enable =
+#The type of the specified codec.
+#account.6.codec.Y.payload_type =
+#The priority of the specified codec. It's available when the codec is enabled.
+#account.6.codec.Y.priority =
+#The payload of the specified codec.
+#account.6.codec.Y.rtpmap =
+
+account.6.codec.1.enable = 1
+account.6.codec.1.payload_type = PCMU
+account.6.codec.1.priority = 1
+account.6.codec.1.rtpmap = 0
+
+account.6.codec.2.enable = 1
+account.6.codec.2.payload_type = PCMA
+account.6.codec.2.priority = 2
+account.6.codec.2.rtpmap = 8
+
+account.6.codec.3.enable = 0
+account.6.codec.3.payload_type = G723_53
+account.6.codec.3.priority =0
+account.6.codec.3.rtpmap = 4
+
+account.6.codec.4.enable = 0
+account.6.codec.4.payload_type = G723_63
+account.6.codec.4.priority = 0
+account.6.codec.4.rtpmap = 4
+
+account.6.codec.5.enable = 1
+account.6.codec.5.payload_type = G729
+account.6.codec.5.priority = 3
+account.6.codec.5.rtpmap = 18
+
+account.6.codec.6.enable = 1
+account.6.codec.6.payload_type = G722
+account.6.codec.6.priority = 4
+account.6.codec.6.rtpmap = 9
+
+account.6.codec.7.enable = 0
+account.6.codec.7.payload_type = iLBC
+account.6.codec.7.priority =  0
+account.6.codec.7.rtpmap = 106
+
+account.6.codec.8.enable = 0
+account.6.codec.8.payload_type = G726-16
+account.6.codec.8.priority = 0
+account.6.codec.8.rtpmap = 103
+
+account.6.codec.9.enable = 0
+account.6.codec.9.payload_type = G726-24
+account.6.codec.9.priority = 0
+account.6.codec.9.rtpmap = 104
+
+account.6.codec.10.enable = 0
+account.6.codec.10.payload_type = G726-32
+account.6.codec.10.priority = 0
+account.6.codec.10.rtpmap = 102
+
+account.6.codec.11.enable = 0
+account.6.codec.11.payload_type = G726-40
+account.6.codec.11.priority = 0
+account.6.codec.11.rtpmap = 105
+
+account.6.codec.12.enable = 0
+account.6.codec.12.payload_type = GSM
+account.6.codec.12.priority = 0
+account.6.codec.12.rtpmap = 3
+
+
+#######################################################################################
+##                            Audio Advanced                                         ##
+#######################################################################################
+#Specify whether to encrypt the SIP messages; 0-Disabled (default), 1-Forced, 2-Negotiated;
+account.6.srtp_encryption =
+
+#Configure the RTP packet time. The valid values are 0 (Disabled), 10, 20 (default), 30, 40, 50, 60.
+account.6.ptime =
+
+
+#######################################################################################
+##                            Anonymous Call                                         ##
+#######################################################################################
+account.6.anonymous_call = 0
+account.6.anonymous_call_oncode =
+account.6.anonymous_call_offcode =
+
+account.6.reject_anonymous_call =
+account.6.anonymous_reject_oncode =
+account.6.anonymous_reject_offcode =
+
+#######################################################################################
+##                            Pickup Code                                            ##
+#######################################################################################
+account.5.dialoginfo_callpickup = 0
+
+#Configure the directed and group pickup codes for account 1, the settings on a per-account basis take precedence over the settings on the phone.
+account.6.group_pickup_code =
+account.56.direct_pickup_code =
+
+#######################################################################################
+##                            DTMF                                                   ##
+#######################################################################################
+#Configure the DTMF type; 0-INBAND, 1-RFC2833 (default), 2-SIP INFO, 3-AUTO+SIP INFO;
+account.6.dtmf.type =
+
+#Configure the DTMF info type when using the SIP INFO; 0-Disabled (default), 1-DTMF-Relay, 2-DTMF, 3-Telephone-Event;
+account.6.dtmf.info_type =
+
+#Configure the RFC2833 payload. It ranges from 96 to 255, the default value is 101.
+account.6.dtmf.dtmf_payload =
+
+#######################################################################################
+##                            Alert info                                             ##
+#######################################################################################
+#Enable or disable to use the Distinctive Ring Tones;  0-Disabled , 1-Enabled(default);
+account.6.alert_info_url_enable =
+
+#Assign a ringtone for account2. The system ring tones are: common (default), Ring1.wav - Ring8.wav.
+#If you set the custom ring tone (Busy.wav) for the phone, the value is: account.2.ringtone.ring_type = Config:Busy.wav
+#If you set the system ring tone (Ring2.wav) for the phone, the value is: account.2.ringtone.ring_type = Resource:Ring2.wav
+account.6.ringtone.ring_type =
+
+account.6.picture_info_enable = 1
+
+#######################################################################################
+##                            Conference                                             ##
+#######################################################################################
+#Configure the conference type; 0-Local (default), 2-Network Conference;
+account.6.conf_type =
+
+#Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
+account.6.conf_uri =
+
+#######################################################################################
+##                            cid source                                             ##
+#######################################################################################
+#Configure the type of SIP header(s) to carry the caller ID; 0-FROM (default), 1-PAI 2-PAI-FROM, 3-PRID-PAI-FROM, 4-PAI-RPID-FROM, 5-RPID-FROM;
+account.6.cid_source = {$yealink_cid_source}
+
+account.6.cid_source_privacy = 1
+account.6.cid_source_ppi = 1
+
+#Configure the presentation of the callee ID; 0-PAI-PRID, 1-DIALED DIGITS (default), 2-RFC4916;
+account.6.cp_source = 2
+
+#######################################################################################
+##                            Session Timer                                          ##
+#######################################################################################
+#Enable or disable the session timer, 0-Disabled (default), 1-Enabled;
+account.6.session_timer.enable = {$yealink_session_timer}
+
+#Configure the refresh session timer interval (in seconds). It ranges from 1 to 9999.
+account.6.session_timer.expires =
+
+#Configure the session timer refresher; 0-Uac (default), 1-Uas;
+account.6.session_timer.refresher =
+
+#######################################################################################
+##                            Music on Hold                                          ##
+#######################################################################################
+#Configure the type of Music on Hold; 0-Send the INVITE request to Music on Hold Server then hold the call; 1-Hold the call then send the INVITE request to Music on Hold Server;
+#Require reboot;
+account.6.music_on_hold_type =
+
+account.6.music_server_uri =
+
+#######################################################################################
+##                            Advanced                                               ##
+#######################################################################################
+#Enable or disable the auto answer feature; 0-Disabled (default), 1-Enabled;
+account.6.auto_answer =
+
+#Enable or disable the phone to record the missed call; 0-Disabled, 1-Enabled (default);
+account.6.missed_calllog =
+
+#Enable or disable the 100 reliable retransmission; 0-Disabled (default), 1-Enabled;
+account.6.100rel_enable = {$yealink_retransmission}
+
+#Enable or disable the "user=phone"; 0-Disabled (default), 1-Enabled;
+account.6.enable_user_equal_phone =
+
+#Enable or disable the simplified header field feature; 0-Disabled, 1-Enabled (default);
+account.6.compact_header_enable =
+
+#######################################################################################
+##                                   DND                                             ##
+#######################################################################################
+account.6.dnd.enable =
+account.6.dnd.on_code =
+account.6.dnd.off_code =
+
+#######################################################################################
+##                                 Call Forward                                      ##
+#######################################################################################
+#Enable or disable the busy forward feature for account; 0-Disabled (default), 1-Enabled;
+account.6.always_fwd.enable =
+account.6.always_fwd.target =
+account.6.always_fwd.off_code =
+account.6.always_fwd.on_code =
+
+account.6.busy_fwd.enable =
+account.6.busy_fwd.target =
+account.6.busy_fwd.off_code =
+account.6.busy_fwd.on_code =
+
+#Enable or disable the no answer forward feature for account1; 0-Disabled (default), 1-Enabled;
+#Configure the waiting ring times before forwarding. It ranges from 0 to 20, the default value is 2.
+account.6.timeout_fwd.enable =
+account.6.timeout_fwd.target =
+account.6.timeout_fwd.timeout =
+account.6.timeout_fwd.off_code =
+account.6.timeout_fwd.on_code =
+
+#######################################################################################
+##                                 Broadsoft Hoteling                                ##
+#######################################################################################
+account.6.hoteling.enable = 0
+account.6.hoteling.user_id = 0
+account.6.hoteling.password = 0
+account.6.hoteling.auto_login_enable = 0
+
+#######################################################################################
+##                                 Broadsoft ACD                                     ##
+#######################################################################################
+account.6.acd.enable = 0
+account.6.acd.unavailable_reason_enable = 0
+account.6.acd.available = 0
+account.6.acd.initial_state = 1
+
+#######################################################################################
+##                                 Broadsoft ACD Call Center                         ##
+#######################################################################################
+#Configure the ACD reason code of Broadsoft.(The valus of Y must be consecutive numbers.)
+#account.6.bw_acd_reason_code.Y = 500(lunch time)
+account.6.bw_acd_reason_code.1 =
+
+account.6.reason_code.1 =
+account.6.reason_code_name.1 = 0
+account.6.bw_disp_code.1 =
+account.6.bw_disp_code_name.1 =
+account.6.supervisor_info_code.1 =
+account.6.supervisor_info_code_name.1 =
+
+#######################################################################################
+##                                 Broadsoft Call Center                             ##
+#######################################################################################
+account.6.call_center.call_info_enable = 0
+account.6.call_center.show_call_info_time = 30
+account.6.call_center.disp_code_enable = 0
+account.6.call_center.trace_enable = 0
+account.6.call_center.emergency_enable = 0
+account.6.call_center.queue_status_enable = 0
+account.6.call_center.queue_status_light_enable = 0
+
+#######################################################################################
+##                                 Broadsoft XSI                                     ##
+#######################################################################################
+account.6.xsi.user =
+account.6.xsi.password =
+account.6.xsi.host =
+account.6.xsi.server_type =
+account.6.xsi.port =
+
+
+#######################################################################################
+##                                   NETWORK                                         ##
+#######################################################################################
+##0-ipv4, 1-ipv6, 2-ipv4&ipv6
+network.ip_address_mode = 2
+
+network.ipv6_prefix = 64
+network.ipv6_internet_port.type =
+network.ipv6_internet_port.ip =
+network.ipv6_internet_port.gateway =
+network.ipv6_primary_dns =
+network.ipv6_secondary_dns =
+network.ipv6_icmp_v6.enable =
+
+#Configure the WAN port type; 0-DHCP (default), 1-PPPoE, 2-Static IP Address;
+#Require reboot;
+network.internet_port.type =
+
+#Configure the static IP address, subnet mask, gateway and DNS server;
+#Require Reboot;
+network.internet_port.ip =
+network.internet_port.mask =
+network.internet_port.gateway =
+{if isset($dns_server_primary)}network.primary_dns = {$dns_server_primary}{/if}
+{if isset($dns_server_secondary)}network.secondary_dns = {$dns_server_secondary}{/if}
+{if isset($dns_server_primary)}network.static_dns_enable = 1{else}network.static_dns_enable = 0{/if}
+
+#######################################################################################
+##                             Line Key                                              ##
+#######################################################################################
+
+#The x of the parameter "linekey.x.line" ranges from 1 to 6.
+#The default value equals to the value of x. For example, the default value of the parameter "linekey.1.line" is 1.
+#linekey.x.lable--Define the label for each line key. Meet-Me Conference "1" or BLF "16" require pick_value.
+
+{foreach $keys['line'] as $row}
 #Configure Line Key {$row.device_key_id}
 linekey.{$row.device_key_id}.line = {$row.device_key_line}
 linekey.{$row.device_key_id}.value = {$row.device_key_value}
+{if $row.device_key_type == "1" || $row.device_key_type == "16"}
 linekey.{$row.device_key_id}.pickup_value = {$row.device_key_extension}
+{else}
 linekey.{$row.device_key_id}.extension = {$row.device_key_extension}
+{/if}
 linekey.{$row.device_key_id}.type = {$row.device_key_type}
 linekey.{$row.device_key_id}.xml_phonebook =
 linekey.{$row.device_key_id}.label = {$row.device_key_label}
 
+{/foreach}
+
+
+#######################################################################################
+##                             Memory Key (For T38G only)                            ##
+#######################################################################################
+#X ranges from 1 to 10;
+#memorykey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
+#The value 0 of the "memorykey.x.line" stands for Auto, it means the first available line.
+#But, when the DSS key is configured as BLF, BLF List, Shared Line, Call Park, Pick Up, ACD or Voice Mail feature, the value 0 stands for line 1.
+#memorykey.x.value--Enter the value of some features. E.g. When configuring the DSS key to be BLF, enter the number of the monitored user.
+#memorykey.x.extension--Enter the pickup code, this parameter is only appilicable to BLF.
+#memorykey.x.type--Assign the desired feature to the memory key.
+#Valid types are:  0-N/A(default for memory key)  1-Conference     2-Forward    3-Transfer      4-Hold        5-DND             6-Redial                        7-Call Return     8-SMS
+#                  9-Call Pickup                  10-Call Park     11-DTMF      12-Voicemail    13-SpeedDial  14-Intercom       15-Line(default for line key)   16-BLF            17-URL
+#                  18-Group Listening             19-Public Hold   20-Private   21-Shared Line  22-XML Group  23-Group Pickup   24-Paging                       25-Record         27-XML Browser
+#                  34-Hot Desking                 35-URL Record    38-LDAP      39-BLF List     40-Prefix     41-Zero-Sp-Touch  42-ACD                          45-Local Group    46-Broadsoft Group
+#memorykey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the DSS key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
+#memorykey.x.sub_type =
+
+{foreach $keys["memory"] as $row}
 #Expansion Memory Key {$row.device_key_id}
 memorykey.{$row.device_key_id}.type = {$row.device_key_type}
 memorykey.{$row.device_key_id}.line = {$row.device_key_line}
@@ -496,25 +3007,113 @@ memorykey.{$row.device_key_id}.label = {$row.device_key_label}
 memorykey.{$row.device_key_id}.xml_phonebook =
 memorykey.{$row.device_key_id}.sub_type =
 
+{/foreach}
+
+
+##########################################################################################
+##                         Programmable Key (For T38G only)                             ##
+##########################################################################################
+#X ranges from 1 to 15.
+#programablekey.x.type--Customize the programmable key type.
+#The valid types are:
+#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
+#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
+#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
+#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
+#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
+#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
+
+{foreach $keys["programmable"] as $row}
 programablekey.{$row.device_key_id}.type = {$row.device_key_type}
 programablekey.{$row.device_key_id}.line = {$row.device_key_line}
 programablekey.{$row.device_key_id}.value = {$row.device_key_value}
 programablekey.{$row.device_key_id}.xml_phonebook =
 programablekey.{$row.device_key_id}.history_type =
 programablekey.{$row.device_key_id}.label = {$row.device_key_label}
+
+{/foreach}
+
+#programablekey.x.value =
+#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
+#programablekey.x.history_type =
+
+#programablekey.x.label--This parameter is only available to the key 1 to key 4.
+
+#History
+#programablekey.1.type = 28
+#programablekey.1.line = 1
+#programablekey.1.value = 
+#programablekey.1.xml_phonebook =
+#programablekey.1.history_type =
+#programablekey.1.label =
+
+#Directory
+#programablekey.2.type = 29
+#programablekey.2.line = 1
+#programablekey.2.value =
+#programablekey.2.xml_phonebook =
+#programablekey.2.history_type =
+#programablekey.2.label =
+
+#DND
+programablekey.3.type = 5
+programablekey.3.line = 1
+programablekey.3.value =
+programablekey.3.xml_phonebook =
+programablekey.3.history_type =
+programablekey.3.label =
+
+#Menu
+#programablekey.4.type = 30
+#programablekey.4.line =
+#programablekey.4.value =
+#programablekey.4.xml_phonebook =
+#programablekey.4.history_type =
+#programablekey.4.label =
+
+##########################################################################################
+##                                  Expansion Module 1                                  ##
+##########################################################################################
+#X ranges from 1 to 16, Y ranges from 1 to 40.
+#expansion_module.x.key.y.type = 37 (Switch by default)
+#expansion_module.x.key.y.line = 0
+#expansion_module.x.key.y.value =
+#expansion_module.x.key.y.extension =
+#expansion_module.x.key.y.label =
+#expansion_module.X.key.Y.xml_phonebook =
+
 {$rownum = 1}
 
+{foreach $keys["expansion"] as $row}
+{if $rownum <= 40}
 expansion_module.1.key.{$row.device_key_id}.type = {$row.device_key_type}
 expansion_module.1.key.{$row.device_key_id}.line = {$row.device_key_line}
 expansion_module.1.key.{$row.device_key_id}.value = {$row.device_key_value}
 expansion_module.1.key.{$row.device_key_id}.extension = {$row.device_key_extension}
 expansion_module.1.key.{$row.device_key_id}.label = {$row.device_key_label}
 expansion_module.1.key.{$row.device_key_id}.xml_phonebook =
-
+{else}
 expansion_module.2.key.{$row.device_key_id - 40}.type = {$row.device_key_type}
 expansion_module.2.key.{$row.device_key_id - 40}.line = {$row.device_key_line}
 expansion_module.2.key.{$row.device_key_id - 40}.value = {$row.device_key_value}
 expansion_module.2.key.{$row.device_key_id - 40}.extension = {$row.device_key_extension}
 expansion_module.2.key.{$row.device_key_id - 40}.label = {$row.device_key_label}
 expansion_module.2.key.{$row.device_key_id - 40}.xml_phonebook =
+{/if}
 {$rownum = $rownum + 1}
+
+{/foreach}
+
+##########################################################################################
+##                                  Expansion Module 2                                  ##
+##########################################################################################
+
+#Expansion module 2 key 1
+#expansion_module.2.key.1.type =
+#expansion_module.2.key.1.line =
+#expansion_module.2.key.1.value =
+#expansion_module.2.key.1.extension =
+#expansion_module.2.key.1.label =
+#expansion_module.2.key.1.xml_phonebook =
+#expansion_module.2.key.1.type =
+#expansion_module.2.key.1.label =

--- a/resources/templates/provision/yealink/t46g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46g/{$mac}.cfg
@@ -175,7 +175,7 @@ account.1.subscribe_mwi = 1
 account.1.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm = 1
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.1.subscribe_acd_expires= 3600
 
@@ -643,7 +643,7 @@ account.2.subscribe_mwi = 1
 account.2.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm = 1
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.2.subscribe_acd_expires= 3600
 
@@ -1125,7 +1125,7 @@ account.3.subscribe_mwi = 1
 account.3.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm = 1
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.3.subscribe_acd_expires= 3600
 
@@ -1597,7 +1597,7 @@ account.4.subscribe_mwi = 1
 account.4.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm = 1
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.4.subscribe_acd_expires= 3600
 
@@ -2069,7 +2069,7 @@ account.5.subscribe_mwi = 1
 account.5.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm = 1
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.5.subscribe_acd_expires= 3600
 
@@ -2540,7 +2540,7 @@ account.6.subscribe_mwi = 0
 account.6.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.6.subscribe_acd_expires= 3600
 

--- a/resources/templates/provision/yealink/t46s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46s/{$mac}.cfg
@@ -1,81 +1,12 @@
 #!version:1.0.0.1
 
 ##File header "#!version:1.0.0.1" can not be edited or deleted, and must be placed in the first line.##
-##account.X.*:(T54S/T48G/T48S/T46G/T46S/T29G: X ranges from 1 to 16. T52S/T42G/T42S: X ranges from 1 to 12. T41P/T41S/T27P/T27G: X ranges from 1 to 6. T40P/T40G/T23P/T23G: X ranges from 1 to 3. T21(P) E2: X ranges from 1 to 2.)##
 
 #######################################################################################
-##                                   Transfer                                        ##       
+##                           Account 1 Basic Settings                                ##
 #######################################################################################
-account.1.phone_setting.call_appearance.transfer_via_new_linekey=
-
-
-#######################################################################################
-##                                   Conference                                      ##       
-#######################################################################################
-account.1.phone_setting.call_appearance.conference_via_new_linekey=
-
-
-#######################################################################################
-##                                   Anonymous                                       ##       
-#######################################################################################
-account.1.anonymous_call.server_base_only =
-account.1.send_anonymous_rejection_code =
-account.1.anonymous_reject_offcode =
-account.1.anonymous_reject_oncode =
-account.1.reject_anonymous_call=
-account.1.anonymous_call_offcode =
-account.1.anonymous_call_oncode =
-account.1.anonymous_call =
-account.1.send_anonymous_code =
-
-
-
-#######################################################################################
-##                          Call Configuration                                       ##       
-#######################################################################################
-account.1.music_server_uri=
-account.1.music_on_hold_type=
-account.1.auto_label.rule=
-account.1.auto_label.enable=
-account.1.number_of_linekey=
-account.1.phone_setting.call_appearance.calls_per_linekey=
-
-
-#######################################################################################
-##                                    Codec                                          ##       
-#######################################################################################
-account.1.codec.ilbc_15_2kbps.priority=
-account.1.codec.ilbc_15_2kbps.enable=
-account.1.codec.ilbc_13_33kbps.priority=
-account.1.codec.ilbc_13_33kbps.enable =
-account.1.codec.pcma.enable=
-account.1.codec.pcma.priority=
-account.1.codec.pcmu.enable=
-account.1.codec.pcmu.priority=
-account.1.codec.opus.priority =
-account.1.codec.opus.enable=
-account.1.codec.opus.para=
-account.1.codec.g726_40.enable=
-account.1.codec.g726_40.priority=
-account.1.codec.g726_32.enable=
-account.1.codec.g726_32.priority=
-account.1.codec.g726_24.enable=
-account.1.codec.g726_24.priority=
-account.1.codec.g726_16.enable=
-account.1.codec.g726_16.priority=
-account.1.codec.g723_63.priority=
-account.1.codec.g723_63.enable=
-account.1.codec.g723_53.priority=
-account.1.codec.g723_53.enable=
-account.1.codec.g729.priority=
-account.1.codec.g729.enable=
-account.1.codec.g722.priority=
-account.1.codec.g722.enable=
-
-################################################################
-#                      Account Register                       ##
-################################################################
-
+## ranges from 1 to 6;
+##account.X.enable =
 {if isset($user_password_1) }
 account.1.enable = 1
 {else}
@@ -86,335 +17,464 @@ account.1.display_name = {$display_name_1}
 account.1.auth_name = {$auth_id_1}
 account.1.password = {$user_password_1}
 account.1.user_name = {$user_id_1}
+account.1.sip_server_host = {$server_address_1}
+account.1.sip_server_port = {$sip_port_1}
+account.1.outbound_host = {$outbound_proxy_1}
+account.1.outbound_port = {$sip_port_1}
+{if isset($yealink_sip_listen_port)}account.1.sip_listen_port = {$yealink_sip_listen_port}{else}account.1.sip_listen_port = 5060{/if}
 
-account.1.sip_server.1.address = {$server_address_1}
-account.1.sip_server.1.port = {$sip_port_1}
-
-{if $sip_transport_1 == 'udp'}account.1.sip_server.1.transport_type = 0{/if}
-{if $sip_transport_1 == 'tcp'}account.1.sip_server.1.transport_type = 1{/if}
-{if $sip_transport_1 == 'tls'}account.1.sip_server.1.transport_type = 2{/if}
-{if $sip_transport_1 == 'dns srv'}account.1.sip_server.1.transport_type = 3{/if}
-
-account.1.sip_server.1.expires = {$register_expires_1}
-account.1.sip_server.1.retry_counts = 3
-
-account.1.sip_server.2.address = {$server_address_2}
-account.1.sip_server.2.port = {$sip_port_2}
-
-{if $sip_transport_1 == 'udp'}account.1.sip_server.2.transport_type = 0{/if}
-{if $sip_transport_1 == 'tcp'}account.1.sip_server.2.transport_type = 1{/if}
-{if $sip_transport_1 == 'tls'}account.1.sip_server.2.transport_type = 2{/if}
-{if $sip_transport_1 == 'dns srv'}account.1.sip_server.2.transport_type = 3{/if}
-
-account.1.sip_server.2.expires = {$register_expires_2}
-account.1.sip_server.2.retry_counts = 3
-
-account.1.outbound_proxy_enable = {if isset($outbound_proxy_primary_1)}1{else}0{/if}
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS SRV;
+{if $sip_transport_1 == 'udp'}account.1.transport = 0{/if}
+{if $sip_transport_1 == 'tcp'}account.1.transport = 1{/if}
+{if $sip_transport_1 == 'tls'}account.1.transport = 2{/if}
+{if $sip_transport_1 == 'dns srv'}account.1.transport = 3{/if}
 
 account.1.outbound_proxy.1.address = {$outbound_proxy_primary_1}
+account.1.outbound_proxy.2.address = {$outbound_proxy_secondary_1}
+account.1.outbound_proxy_enable = {if isset($outbound_proxy_primary_1)}1{else}0{/if}
 
 {if isset($outbound_proxy_1_port)}
 account.1.outbound_proxy.1.port = {$outbound_proxy_1_port}
 {else}
 account.1.outbound_proxy.1.port = 5060
 {/if}
-
-account.1.outbound_proxy.2.address = {$outbound_proxy_secondary_1}
-
 {if isset($outbound_proxy_1_port)}
 account.1.outbound_proxy.2.port = {$outbound_proxy_2_port}
 {else}
 account.1.outbound_proxy.2.port = 5060
 {/if}
 
-{if isset($outbound_proxy_fallback_interval)}
-account.1.outbound_proxy_fallback_interval = {$outbound_proxy_fallback_interval}
-{else}
-account.1.outbound_proxy_fallback_interval = 120
-{/if}
+#######################################################################################
+##                          Failback                                                 ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.reregister_enable = 0
 
+account.1.reregister_enable = 0
+account.1.retry_counts =
+account.1.failback_mode = 0
+account.1.failback_timeout = 3600
+account.1.naptr_build = 0
+account.1.fallback.redundancy_type = 0
+account.1.fallback.timeout = {$yealink_outbound_proxy_fallback_interval}
+account.1.sip_server.1.address =
+{if $sip_transport_1 == 'dns srv'}
+account.1.sip_server.1.port = 0
+{else}
+account.1.sip_server.1.port = {$sip_port_1}
+{/if}
+#Configure the register expiry time (in seconds), the default value is 3600.
+account.1.sip_server.1.expires = {$register_expires_1}
+account.1.sip_server.1.retry_counts = 3
+account.1.sip_server.1.failback_mode = 0
+account.1.sip_server.1.failback_timeout = 3600
+account.1.sip_server.1.register_on_enable = 0
+account.1.sip_server.2.address =
+account.1.sip_server.2.port = 5060
+account.1.sip_server.2.expires = 3600
+account.1.sip_server.2.retry_counts = 3
+account.1.sip_server.2.failback_mode = 0
+account.1.sip_server.2.failback_timeout = 3600
+account.1.sip_server.2.register_on_enable = 0
+account.1.dns_cache_type = 1
+
+account.1.dns_cache_a.1.name =
+account.1.dns_cache_a.1.ip =
+account.1.dns_cache_a.1.ttl = 300
+
+account.1.dns_cache_srv.1.name =
+account.1.dns_cache_srv.1.port = 0
+account.1.dns_cache_srv.1.priority = 0
+account.1.dns_cache_srv.1.target =
+account.1.dns_cache_srv.1.weight = 0
+account.1.dns_cache_srv.1.ttl = 300
+account.1.dns_cache_naptr.1.name =
+account.1.dns_cache_naptr.1.flags =
+account.1.dns_cache_naptr.1.order = 0
+account.1.dns_cache_naptr.1.preference = 0
+account.1.dns_cache_naptr.1.replace =
+account.1.dns_cache_naptr.1.service =
+account.1.dns_cache_naptr.1.ttl = 300
+
+account.1.static_cache_pri = 0
+
+#######################################################################################
+##                           Register Advanced                                       ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.sip_server_type =
+
+#Configure the SIP server type; 0-Default (default), 2-BroadSoft, 4-Cosmocom;
+account.1.sip_server_type =
+#Enable or disable the phone to send the account log-off message first and then send account register message when rebooting the phone; 0-Disabled (default), 1-Enabled;
+account.1.unregister_on_reboot =
+
+#Enable or disable the phone to only accept the message from the server; 0-Disabled (default), 1-Enabled;
+account.1.sip_trust_ctrl = 1
+
+#Configure the timeout (in seconds) for DNS query, the value ranges from 1 to 9, the default value is 8.
+account.1.dns_query_timeout=
+
+#Enable or disable the timer to periodically refresh the DNS-SRV query result; 0-Disabled (default), 1-Enabled;
+account.1.srv_ttl_timer_enable =
+account.1.proxy_require =
+
+
+#Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
+account.1.register_mac =
+account.1.register_line =
+
+#Configure the interval (in seconds) the phone retries to register when account1 fails to register. It ranges from 0 to 1800, the default value is 30.
+account.1.reg_fail_retry_interval =
+
+#########################################################################
+##                     NAT Settings                                    ##
+#########################################################################
+
+#Enable or disable the NAT traversal; 0-Disabled (default), 1-STUN;
 account.1.nat.nat_traversal = {if isset($stun_server)}1{else}0{/if}
 
-################################################################
-#                      Account Basic                          ##
-################################################################
-account.1.proxy_require=
-account.1.auto_answer=
+#Configure the STUN server address.
+account.1.nat.stun_server = {$stun_server}
 
-################################################################
-#                      Account Advanced                       ##
-################################################################
-account.1.nat.udp_update_enable= 3
-account.1.nat.udp_update_time= 30
-account.1.nat.rport= {$yealink_rport}
+#Configure the STUN server port, the default value is 3478.
+account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-account.1.dtmf.type=
-account.1.dtmf.info_type=
-account.1.dtmf.dtmf_payload=
-account.1.100rel_enable= {$yealink_retransmission}
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.1.nat.udp_update_enable = 3
 
-account.1.subscribe_register=
-account.1.cid_source = {$yealink_cid_source}
-account.1.enable_user_equal_phone=
+#Specify the keep-alive interval (in seconds), the default value is 30.
+account.1.nat.udp_update_time = 30
+
+#Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
+account.1.nat.rport = {$yealink_rport}
+
+
+#######################################################################################
+##                            AccountX Advance Settings                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.advanced.timer_t1 = 0.5
+##voice_mail.number.X =
+
+#Configure the session timer (in seconds), the default value of T1, T2, T3 is 0.5, 4, 5.
+account.1.advanced.timer_t1 =
+account.1.advanced.timer_t2 =
+account.1.advanced.timer_t4 =
+
+voice_mail.number.1 = {$voicemail_number}
+
+
+#######################################################################################
+##                            Subscribe                                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.subscribe_mwi =
+
+account.1.subscribe_mwi = 1
+account.1.subscribe_mwi_expires = 3600
+
+#Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
+
+account.1.subscribe_acd_expires= 3600
+
+
+#######################################################################################
+##                            BLF List                                               ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.blf.blf_list_uri =
+
+#Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
+account.1.blf.blf_list_uri =
+
+account.1.blf_list_code =
+account.1.blf_list_barge_in_code =
+account.1.blf.subscribe_period = 1800
+
+account.1.blf.subscribe_event =
+account.1.out_dialog_blf_enable = 0
+
+
+#######################################################################################
+##                            BLA/SCA                                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.shared_line =
+
+#Assign account1 as shared line; 0-Disabled (default), 1-Broadsoft SCA, 2-BLA;
+{if isset($shared_line_1) }
+account.1.shared_line = {$shared_line_1}
+{else}
+account.1.shared_line = 0
+{/if}
+
+#Configure BLA number for account1 and the subscribe period (in seconds). It ranges from 60 to 7200, the default value is 300.
+account.1.bla_number =
+account.1.bla_subscribe_period = 300
+
+#######################################################################################
+##                            Audio Codec                                            ##
+#######################################################################################
+#Audio codecs for account1 (Y ranges from 1 to 11).
+#Enable or disable the specified codec; 0-Disabled, 1-Enabled;
+#account.1.codec.Y.enable =
+#The type of the specified codec.
+#account.1.codec.Y.payload_type =
+#The priority of the specified codec. It's available when the codec is enabled.
+#account.1.codec.Y.priority =
+#The payload of the specified codec.
+#account.1.codec.Y.rtpmap =
+
+account.1.codec.1.enable = 1
+account.1.codec.1.payload_type = PCMU
+account.1.codec.1.priority = 2
+account.1.codec.1.rtpmap = 0
+
+account.1.codec.2.enable = 1
+account.1.codec.2.payload_type = PCMA
+account.1.codec.2.priority = 3
+account.1.codec.2.rtpmap = 8
+
+account.1.codec.3.enable = 0
+account.1.codec.3.payload_type = G723_53
+account.1.codec.3.priority =0
+account.1.codec.3.rtpmap = 4
+
+account.1.codec.4.enable = 0
+account.1.codec.4.payload_type = G723_63
+account.1.codec.4.priority = 0
+account.1.codec.4.rtpmap = 4
+
+account.1.codec.5.enable = 1
+account.1.codec.5.payload_type = G729
+account.1.codec.5.priority = 3
+account.1.codec.5.rtpmap = 18
+
+account.1.codec.6.enable = 1
+account.1.codec.6.payload_type = G722
+account.1.codec.6.priority = 1
+account.1.codec.6.rtpmap = 9
+
+account.1.codec.7.enable = 0
+account.1.codec.7.payload_type = iLBC
+account.1.codec.7.priority =  0
+account.1.codec.7.rtpmap = 106
+
+account.1.codec.8.enable = 0
+account.1.codec.8.payload_type = G726-16
+account.1.codec.8.priority = 0
+account.1.codec.8.rtpmap = 103
+
+account.1.codec.9.enable = 0
+account.1.codec.9.payload_type = G726-24
+account.1.codec.9.priority = 0
+account.1.codec.9.rtpmap = 104
+
+account.1.codec.10.enable = 0
+account.1.codec.10.payload_type = G726-32
+account.1.codec.10.priority = 0
+account.1.codec.10.rtpmap = 102
+
+account.1.codec.11.enable = 0
+account.1.codec.11.payload_type = G726-40
+account.1.codec.11.priority = 0
+account.1.codec.11.rtpmap = 105
+
+account.1.codec.12.enable = 0
+account.1.codec.12.payload_type = GSM
+account.1.codec.12.priority = 0
+account.1.codec.12.rtpmap = 3
+
+
+#######################################################################################
+##                            Audio Advanced                                         ##
+#######################################################################################
+#Specify whether to encrypt the SIP messages; 0-Disabled (default), 1-Forced, 2-Negotiated;
 account.1.srtp_encryption = {$yealink_srtp_encryption}
-account.1.ptime= 20
-account.1.register_line=
-account.1.register_mac=
-account.1.reg_fail_retry_interval=
-account.1.unregister_on_reboot=
 
-account.1.session_timer.refresher=
-account.1.session_timer.expires=
+#Configure the RTP packet time. The valid values are 0 (Disabled), 10, 20 (default), 30, 40, 50, 60.
+account.1.ptime =
+
+
+#######################################################################################
+##                            Anonymous Call                                         ##
+#######################################################################################
+account.1.anonymous_call = 0
+account.1.anonymous_call_oncode =
+account.1.anonymous_call_offcode =
+
+account.1.reject_anonymous_call =
+account.1.anonymous_reject_oncode =
+account.1.anonymous_reject_offcode =
+
+#######################################################################################
+##                            Pickup Code                                            ##
+#######################################################################################
+account.1.dialoginfo_callpickup = 0
+
+#Configure the directed and group pickup codes for account 1, the settings on a per-account basis take precedence over the settings on the phone.
+account.1.group_pickup_code =
+account.1.direct_pickup_code =
+
+#######################################################################################
+##                            DTMF                                                   ##
+#######################################################################################
+#Configure the DTMF type; 0-INBAND, 1-RFC2833 (default), 2-SIP INFO, 3-AUTO+SIP INFO;
+account.1.dtmf.type =
+
+#Configure the DTMF info type when using the SIP INFO; 0-Disabled (default), 1-DTMF-Relay, 2-DTMF, 3-Telephone-Event;
+account.1.dtmf.info_type =
+
+#Configure the RFC2833 payload. It ranges from 96 to 255, the default value is 101.
+account.1.dtmf.dtmf_payload =
+
+#######################################################################################
+##                            Alert info                                             ##
+#######################################################################################
+#Enable or disable to use the Distinctive Ring Tones; 0-Disabled , 1-Enabled(default);
+account.1.alert_info_url_enable =
+
+#Assign a ringtone for account1. The system ring tones are: common (default), Ring1.wav - Ring8.wav.
+#If you set the custom ring tone (Busy.wav) for the phone, the value is: account.1.ringtone.ring_type = Config:Busy.wav
+#If you set the system ring tone (Ring2.wav) for the phone, the value is: account.1.ringtone.ring_type = Resource:Ring2.wav
+account.1.ringtone.ring_type =
+
+account.1.picture_info_enable = 1
+
+#######################################################################################
+##                            Conference                                             ##
+#######################################################################################
+#Configure the conference type; 0-Local (default), 2-Network Conference;
+account.1.conf_type =
+
+#Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
+account.1.conf_uri =
+
+#######################################################################################
+##                            cid_source                                             ##
+#######################################################################################
+#Configure the type of SIP header(s) to carry the caller ID; 0-FROM (default), 1-PAI 2-PAI-FROM, 3-PRID-PAI-FROM, 4-PAI-RPID-FROM, 5-RPID-FROM;
+account.1.cid_source = {$yealink_cid_source}
+
+account.1.cid_source_privacy = 1
+account.1.cid_source_ppi = 1
+
+#Configure the presentation of the callee ID; 0-PAI-PRID, 1-DIALED DIGITS (default), 2-RFC4916;
+account.1.cp_source = 2
+
+#######################################################################################
+##                            Session Timer                                          ##
+#######################################################################################
+#Enable or disable the session timer, 0-Disabled (default), 1-Enabled;
 account.1.session_timer.enable = {$yealink_session_timer}
 
-account.1.conf_type=
-account.1.sip_server_type=
+#Configure the refresh session timer interval (in seconds). It ranges from 1 to 9999.
+account.1.session_timer.expires =
 
-
-################################################################
-#                        SIP Backup Server                    ##
-################################################################
-
-account.1.outbound_proxy.1.register_on_enable=
-account.1.outbound_proxy.1.failback_timeout=
-account.1.outbound_proxy.1.failback_mode=
-account.1.outbound_proxy.1.retry_counts=
-account.1.outbound_proxy.1.only_signal_with_registered=
-account.1.outbound_proxy.1.failback_subscribe.enable=
-account.1.outbound_proxy.1.invite_retry_counts=
-
-account.1.sip_server.1.register_on_enable= 0
-account.1.sip_server.1.failback_timeout= 3600
-account.1.sip_server.1.failback_mode= 0
-account.1.sip_server.1.failback_subscribe.enable= 
-account.1.sip_server.1.only_signal_with_registered=
-account.1.sip_server.1.invite_retry_counts=
-
-account.1.outbound_proxy.2.register_on_enable=
-account.1.outbound_proxy.2.failback_timeout=
-account.1.outbound_proxy.2.failback_mode=
-account.1.outbound_proxy.2.retry_counts=
-account.1.outbound_proxy.2.only_signal_with_registered=
-account.1.outbound_proxy.2.failback_subscribe.enable=
-account.1.outbound_proxy.2.invite_retry_counts=
-
-account.1.sip_server.2.register_on_enable=
-account.1.sip_server.2.failback_timeout=
-account.1.sip_server.2.failback_mode=
-account.1.sip_server.2.failback_subscribe.enable=
-account.1.sip_server.2.only_signal_with_registered=
-account.1.sip_server.2.invite_retry_counts=
-
-account.1.static_cache_pri=
-account.1.dns_cache_type=
-account.1.naptr_build=
-account.1.fallback.timeout = {$yealink_outbound_proxy_fallback_interval}
-account.1.fallback.redundancy_type=
-account.1.reg_failed_retry_max_time=
-account.1.reg_failed_retry_min_time=
-account.1.redundancy_with_reg_fail.enable =
-
-
-################################################################
-#                        SIP Basic config                     ##
-################################################################
-account.1.contact_take_line_param.enable=
-account.1.update_ack_while_dialing=
-account.1.srtp_lifetime=
-account.1.third_part_request_with_route.enable=
-account.1.insert_outbound_in_route.enable=
-account.1.path.enable=
-account.1.rereg_with_auth.enable=
-account.1.sub_fail_retry_interval=
-account.1.transfer_refer_to_contact_header.enable=
-account.1.hold_use_inactive=
-account.1.gruu.enable=
-account.1.dial_tone=
-account.1.call_id_mode=
-account.1.subscribe_expires_overlap=
-account.1.register_expires_overlap=
-account.1.call_info=
-account.1.custom_ua=
-account.1.mwi_parse_terminated=
-account.1.check_cseq.enable=
-account.1.check_to_tag.enable=
-account.1.vq_rtcpxr.collector_server_port=
-account.1.vq_rtcpxr.collector_server_host=
-account.1.vq_rtcpxr.collector_name=
-account.1.compact_header_enable=
-account.1.cp_source=
-account.1.cid_source_ppi=
-account.1.cid_source_privacy=
-
-account.1.alert_info=
-account.1.picture_info_enable=
-
+#Configure the session timer refresher; 0-Uac (default), 1-Uas;
+account.1.session_timer.refresher =
 
 #######################################################################################
-##                                 History                                           ##       
+##                            Music on Hold                                          ##
 #######################################################################################
-account.1.missed_calllog=
+#Configure the type of Music on Hold; 0-Send the INVITE request to Music on Hold Server then hold the call; 1-Hold the call then send the INVITE request to Music on Hold Server;
+#Require reboot;
+account.1.music_on_hold_type =
 
-
-#######################################################################################  
-##                                  Forward                                          ##  
-####################################################################################### 
-account.1.timeout_fwd.off_code=
-account.1.timeout_fwd.on_code=
-account.1.timeout_fwd.timeout=
-account.1.timeout_fwd.target=
-account.1.timeout_fwd.enable=
-account.1.busy_fwd.off_code=
-account.1.busy_fwd.on_code=
-account.1.busy_fwd.target=
-account.1.busy_fwd.enable=
-account.1.always_fwd.off_code=
-account.1.always_fwd.on_code=
-account.1.always_fwd.target=
-account.1.always_fwd.enable=
-
-
-#######################################################################################  
-##                                  DND                                              ##  
-#######################################################################################
-account.1.dnd.enable=
-account.1.dnd.off_code=
-account.1.dnd.on_code=
-
-
-
-#######################################################################################  
-##                               Voice Mail                                          ##  
-#######################################################################################
-voice_mail.number.1= {$voicemail_number}
-account.1.subscribe_mwi=
-account.1.subscribe_mwi_to_vm=
-account.1.subscribe_mwi_expires=
-account.1.display_mwi.enable=
-
-#######################################################################################  
-##                               Auto Dial                                           ##  
-#######################################################################################
-account.1.auto_dial_enable=
-account.1.auto_dial_num=
-
+account.1.music_server_uri =
 
 #######################################################################################
-##                           Preference&Status                                       ##       
+##                            Advanced                                               ##
 #######################################################################################
-account.1.ringtone.ring_type=
+#Enable or disable the auto answer feature; 0-Disabled (default), 1-Enabled;
+account.1.auto_answer =
+
+#Enable or disable the phone to record the missed call; 0-Disabled, 1-Enabled (default);
+account.1.missed_calllog =
+
+#Enable or disable the 100 reliable retransmission; 0-Disabled (default), 1-Enabled;
+account.1.100rel_enable = {$yealink_retransmission}
+
+#Enable or disable the "user=phone"; 0-Disabled (default), 1-Enabled;
+account.1.enable_user_equal_phone =
+
+#Enable or disable the simplified header field feature; 0-Disabled, 1-Enabled (default);
+account.1.compact_header_enable =
 
 #######################################################################################
-##                           Digitmap                                                ##       
+##                                   DND                                             ##
 #######################################################################################
-account.1.dialplan.digitmap.enable=
-account.1.dialplan.digitmap.string=
-account.1.dialplan.digitmap.no_match_action=
-account.1.dialplan.digitmap.interdigit_short_timer=
-account.1.dialplan.digitmap.interdigit_long_timer=
-account.1.dialplan.digitmap.apply_to.press_send=
-account.1.dialplan.digitmap.apply_to.forward=
-account.1.dialplan.digitmap.apply_to.history_dial=
-account.1.dialplan.digitmap.apply_to.directory_dial=
-account.1.dialplan.digitmap.apply_to.on_hook_dial=
-account.1.dialplan.digitmap.active.on_hook_dialing=
-
+account.1.dnd.enable =
+account.1.dnd.on_code =
+account.1.dnd.off_code =
 
 #######################################################################################
-##                                 Rings Settings                                    ##
+##                                 Call Forward                                      ##
 #######################################################################################
-account.1.alert_info_url_enable=
 
+account.1.always_fwd.enable =
+account.1.always_fwd.target =
+account.1.always_fwd.off_code =
+account.1.always_fwd.on_code =
 
-#######################################################################################
-##                                  BLF/BLF List                                     ##       
-#######################################################################################
-account.1.blf.blf_list_uri=
-account.1.blf_list_barge_in_code=
-account.1.blf_list_code=
-account.1.blf_list_retrieve_call_parked_code=
-account.1.blf.subscribe_period=
-account.1.blf.match_host.enable=
-account.1.out_dialog_blf_enable=
-account.1.blf.subscribe_event=
+account.1.busy_fwd.enable =
+account.1.busy_fwd.target =
+account.1.busy_fwd.off_code =
+account.1.busy_fwd.on_code =
 
-#######################################################################################
-##                                   SCA                                             ##       
-#######################################################################################
-account.1.shared_line = {$shared_line_1}
-account.1.line_seize.expires=
-account.1.shared_line_one_touch_bargein.enable=
-account.1.shared_line_one_touch_retrieve.enable=
-account.1.sca_manage_interface_display_time=
-account.1.shared_line_callpull_code=
+#Enable or disable the no answer forward feature for account1; 0-Disabled (default), 1-Enabled;
+#Configure the waiting ring times before forwarding. It ranges from 0 to 20, the default value is 2.
+account.1.timeout_fwd.enable =
+account.1.timeout_fwd.target =
+account.1.timeout_fwd.timeout =
+account.1.timeout_fwd.off_code =
+account.1.timeout_fwd.on_code =
 
 #######################################################################################
-##                                   BLA                                             ##       
+##                                 Broadsoft Hoteling                                ##
 #######################################################################################
-account.1.bla_number=
-account.1.bla_subscribe_period=
-account.1.bla.notify_with_expire.enable=
-account.1.bla.subscribe_uri_build_type=
+account.1.hoteling.enable = 0
+account.1.hoteling.user_id = 0
+account.1.hoteling.password = 0
+account.1.hoteling.auto_login_enable = 0
 
 #######################################################################################
-##                                   Call Park                                       ##       
+##                                 Broadsoft ACD                                     ##
 #######################################################################################
-account.1.callpark_enable=
-
-
-#######################################################################################
-##                                    Broadsoft ACD                                  ##       
-#######################################################################################
-account.1.acd.enable=
-account.1.acd.available=
-account.1.acd.unavailable_reason_enable=
-account.1.acd.initial_state=
-account.1.subscribe_acd_expires=
-
+account.1.acd.enable = 0
+account.1.acd.unavailable_reason_enable = 0
+account.1.acd.available = 0
+account.1.acd.initial_state = 1
 
 #######################################################################################
-##                                 Broadsoft ACD Call Center                         ##       
+##                                 Broadsoft ACD Call Center                         ##
 #######################################################################################
-##account.X.reason_code.Y=
-##account.X.reason_code_name.Y=
-##account.X.bw_disp_code.Y=
-##account.X.bw_disp_code_name.Y=
-##account.X.supervisor_info_code.Y=
-##account.X.supervisor_info_code_name.Y=
-##The value Y must be continuous.
+#Configure the ACD reason code of Broadsoft.(The valus of Y must be consecutive numbers.)
+#account.1.bw_acd_reason_code.Y = 500(lunch time)
+account.1.bw_acd_reason_code.1 =
 
-account.1.reason_code.1=
-account.1.reason_code_name.1=
-account.1.bw_disp_code.1=
-account.1.bw_disp_code_name.1=
-account.1.supervisor_info_code.1=
-account.1.supervisor_info_code_name.1=
+account.1.reason_code.1 =
+account.1.reason_code_name.1 = 0
+account.1.bw_disp_code.1 =
+account.1.bw_disp_code_name.1 =
+account.1.supervisor_info_code.1 =
+account.1.supervisor_info_code_name.1 =
 
 #######################################################################################
-##                                 Broadsoft Call Center                             ##       
+##                                 Broadsoft Call Center                             ##
 #######################################################################################
-account.1.call_center.call_info_enable=
-account.1.call_center.show_call_info_time=
-account.1.call_center.disp_code_enable=
-account.1.call_center.trace_enable=
-account.1.call_center.emergency_enable=
-account.1.call_center.queue_status_enable=
-account.1.call_center.queue_status_light_enable =
-
-
+account.1.call_center.call_info_enable = 0
+account.1.call_center.show_call_info_time = 30
+account.1.call_center.disp_code_enable = 0
+account.1.call_center.trace_enable = 0
+account.1.call_center.emergency_enable = 0
+account.1.call_center.queue_status_enable = 0
+account.1.call_center.queue_status_light_enable = 0
 
 #######################################################################################
-##                         Broadsoft Hoteling                                        ##       
-#######################################################################################
-account.1.hoteling.enable=
-account.1.hoteling.user_id=
-account.1.hoteling.password=
-account.1.hoteling.expires=
-account.1.hoteling.auto_login_enable=
-
-
-#######################################################################################
-##                              Broadsoft XSI                                        ##       
+##                                 Broadsoft XSI                                     ##
 #######################################################################################
 account.1.xsi.user =
 account.1.xsi.password =
@@ -424,69 +484,2416 @@ account.1.xsi.port =
 
 
 #######################################################################################
-##                                Call Pickup                                        ##       
+##                           Account 2 Basic Settings                                ##
 #######################################################################################
-account.1.direct_pickup_code =
-account.1.group_pickup_code =
-account.1.dialoginfo_callpickup =
-account.1.refresh_remote_id.enable =
+## ranges from 1 to 6;
+##account.X.enable =
+{if isset($user_password_2) }
+account.2.enable = 1
+{else}
+account.2.enable = 0
+{/if}
+account.2.label = {$display_name_2}
+account.2.display_name = {$display_name_2}
+account.2.auth_name = {$auth_id_2}
+account.2.password = {$user_password_2}
+account.2.user_name = {$user_id_2}
+account.2.sip_server_host = {$server_address_2}
+account.2.sip_server_port = {$sip_port_2}
+account.2.outbound_host = {$outbound_proxy_2}
+
+account.2.outbound_port = {$sip_port_1}
+{if isset($yealink_sip_listen_port)}account.2.sip_listen_port = {$yealink_sip_listen_port}{else}account.2.sip_listen_port = 5060{/if}
+
+account.2.sip_listen_port = 5060
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS SRV;
+{if $sip_transport_2 == 'udp'}account.2.transport = 0{/if}
+{if $sip_transport_2 == 'tcp'}account.2.transport = 1{/if}
+{if $sip_transport_2 == 'tls'}account.2.transport = 2{/if}
+{if $sip_transport_2 == 'dns srv'}account.2.transport = 3{/if}
+
+account.2.outbound_proxy.1.address = {$outbound_proxy_primary_2}
+account.2.outbound_proxy.2.address = {$outbound_proxy_secondary_2}
+account.2.outbound_proxy_enable = {if isset($outbound_proxy_primary_2)}1{else}0{/if}
+
+#######################################################################################
+##                          Failback                                                 ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.reregister_enable = 0
+
+account.2.reregister_enable = 0
+account.2.retry_counts =
+account.2.failback_mode = 0
+account.2.failback_timeout = 3600
+account.2.naptr_build = 0
+account.2.fallback.redundancy_type = 0
+account.2.fallback.timeout = {$yealink_outbound_proxy_fallback_interval}
+account.2.sip_server.1.address =
+account.2.sip_server.1.port = 5060
+#Configure the register expiry time (in seconds), the default value is 3600.
+account.2.sip_server.1.expires = {$register_expires_2}
+account.2.sip_server.1.retry_counts = 3
+account.2.sip_server.1.failback_mode = 0
+account.2.sip_server.1.failback_timeout = 3600
+account.2.sip_server.1.register_on_enable = 0
+account.2.sip_server.2.address =
+account.2.sip_server.2.port = 5060
+account.2.sip_server.2.expires = 3600
+account.2.sip_server.2.retry_counts = 3
+account.2.sip_server.2.failback_mode = 0
+account.2.sip_server.2.failback_timeout = 3600
+account.2.sip_server.2.register_on_enable = 0
+account.2.dns_cache_type = 1
+
+account.2.dns_cache_a.1.name =
+account.2.dns_cache_a.1.ip =
+account.2.dns_cache_a.1.ttl = 300
+
+account.2.dns_cache_srv.0.name =
+account.2.dns_cache_srv.0.port = 0
+account.2.dns_cache_srv.0.priority = 0
+account.2.dns_cache_srv.0.target =
+account.2.dns_cache_srv.0.weight = 0
+account.2.dns_cache_srv.0.ttl = 300
+account.2.dns_cache_naptr.0.name =
+account.2.dns_cache_naptr.0.flags =
+account.2.dns_cache_naptr.0.order = 0
+account.2.dns_cache_naptr.0.preference = 0
+account.2.dns_cache_naptr.0.replace =
+account.2.dns_cache_naptr.0.service =
+account.2.dns_cache_naptr.0.ttl = 300
+
+account.2.static_cache_pri = 0
+
+#######################################################################################
+##                           Register Advanced                                       ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.sip_server_type =
+
+#Configure the SIP server type; 0-Default (default), 2-BroadSoft, 4-Cosmocom;
+account.2.sip_server_type =
+#Enable or disable the phone to send the account log-off message first and then send account register message when rebooting the phone; 0-Disabled (default), 1-Enabled;
+account.2.unregister_on_reboot =
+
+#Enable or disable the phone to only accept the message from the server; 0-Disabled (default), 1-Enabled;
+account.2.sip_trust_ctrl = 1
+
+#Configure the timeout (in seconds) for DNS query, the value ranges from 1 to 9, the default value is 8.
+account.2.dns_query_timeout=
+
+#Enable or disable the timer to periodically refresh the DNS-SRV query result; 0-Disabled (default), 1-Enabled;
+account.2.srv_ttl_timer_enable =
+account.2.proxy_require =
+
+
+#Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
+account.2.register_mac =
+account.2.register_line =
+
+#Configure the interval (in seconds) the phone retries to register when account1 fails to register. It ranges from 0 to 1800, the default value is 30.
+account.2.reg_fail_retry_interval =
+
+#########################################################################
+##                     NAT Settings                                    ##
+#########################################################################
+
+#Enable or disable the NAT traversal; 0-Disabled (default), 1-STUN;
+account.2.nat.nat_traversal = {if isset($stun_server)}1{else}0{/if}
+
+#Configure the STUN server address.
+account.2.nat.stun_server = {$stun_server}
+
+#Configure the STUN server port, the default value is 3478.
+account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
+
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.2.nat.udp_update_enable = 1
+
+#Specify the keep-alive interval (in seconds), the default value is 30.
+account.2.nat.udp_update_time = 30
+
+#Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
+account.2.nat.rport = {$yealink_rport}
 
 
 #######################################################################################
-##                              Broadsoft Call Recording                             ##       
+##                            Account2 Advance Settings                              ##
 #######################################################################################
-account.1.call_recording.enable=
+## ranges from 1 to 6;
+##account.X.advanced.timer_t1 = 0.5
+##voice_mail.number.X =
 
-#######################################################################################
-##                                Network Conferene                                  ##       
-#######################################################################################
-account.1.conf_uri=
+#Configure the session timer (in seconds), the default value of T1, T2, T3 is 0.5, 4, 5.
+account.2.advanced.timer_t1 = 0.5
+account.2.advanced.timer_t2 = 4
+account.2.advanced.timer_t4 = 5
 
-
-#######################################################################################
-##                              Broadsoft Call Decline                               ##       
-#######################################################################################
-account.1.features.call_decline.enable =
+voice_mail.number.2 = *97
 
 
 #######################################################################################
-##                       Broadsoft Security Classification                           ##       
+##                            Subscribe                                              ##
 #######################################################################################
-account.1.security_classification.enable =
+## ranges from 1 to 6;
+##account.X.subscribe_mwi =
+
+account.2.subscribe_mwi = 1
+account.2.subscribe_mwi_expires = 3600
+
+#Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
+
+account.2.subscribe_acd_expires= 3600
 
 
+#######################################################################################
+##                            BLF List                                               ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.blf.blf_list_uri =
+
+#Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
+account.2.blf.blf_list_uri =
+
+account.2.blf_list_code =
+account.2.blf_list_barge_in_code =
+account.2.blf.subscribe_period = 1800
+
+account.2.blf.subscribe_event =
+account.2.out_dialog_blf_enable = 0
+
 
 #######################################################################################
-##                        Broadsoft Flexible Seating                                 ##       
+##                            BLA/SCA                                                ##
 #######################################################################################
-account.1.flexible_seating.enable=
-account.1.hoteling.pin=
-account.1.hoteling.mode=
+## ranges from 1 to 6;
+##account.X.shared_line =
+
+#Assign account1 as shared line; 0-Disabled (default), 1-Broadsoft SCA, 2-BLA;
+{if isset($shared_line_2) }
+account.2.shared_line = {$shared_line_2}
+{else}
+account.2.shared_line = 0
+{/if}
+
+#Configure BLA number for account1 and the subscribe period (in seconds). It ranges from 60 to 7200, the default value is 300.
+account.2.bla_number =
+account.2.bla_subscribe_period = 300
+
+#######################################################################################
+##                            Audio Codec                                            ##
+#######################################################################################
+#Audio codecs for account1 (Y ranges from 1 to 11).
+#Enable or disable the specified codec; 0-Disabled, 1-Enabled;
+#account.2.codec.Y.enable =
+#The type of the specified codec.
+#account.2.codec.Y.payload_type =
+#The priority of the specified codec. It's available when the codec is enabled.
+#account.2.codec.Y.priority =
+#The payload of the specified codec.
+#account.2.codec.Y.rtpmap =
+
+account.2.codec.1.enable = 1
+account.2.codec.1.payload_type = PCMU
+account.2.codec.1.priority = 2
+account.2.codec.1.rtpmap = 0
+
+account.2.codec.2.enable = 1
+account.2.codec.2.payload_type = PCMA
+account.2.codec.2.priority = 3
+account.2.codec.2.rtpmap = 8
+
+account.2.codec.3.enable = 0
+account.2.codec.3.payload_type = G723_53
+account.2.codec.3.priority =0
+account.2.codec.3.rtpmap = 4
+
+account.2.codec.4.enable = 0
+account.2.codec.4.payload_type = G723_63
+account.2.codec.4.priority = 0
+account.2.codec.4.rtpmap = 4
+
+account.2.codec.5.enable = 1
+account.2.codec.5.payload_type = G729
+account.2.codec.5.priority = 3
+account.2.codec.5.rtpmap = 18
+
+account.2.codec.6.enable = 1
+account.2.codec.6.payload_type = G722
+account.2.codec.6.priority = 1
+account.2.codec.6.rtpmap = 9
+
+account.2.codec.7.enable = 0
+account.2.codec.7.payload_type = iLBC
+account.2.codec.7.priority =  0
+account.2.codec.7.rtpmap = 106
+
+account.2.codec.8.enable = 0
+account.2.codec.8.payload_type = G726-16
+account.2.codec.8.priority = 0
+account.2.codec.8.rtpmap = 103
+
+account.2.codec.9.enable = 0
+account.2.codec.9.payload_type = G726-24
+account.2.codec.9.priority = 0
+account.2.codec.9.rtpmap = 104
+
+account.2.codec.10.enable = 0
+account.2.codec.10.payload_type = G726-32
+account.2.codec.10.priority = 0
+account.2.codec.10.rtpmap = 102
+
+account.2.codec.11.enable = 0
+account.2.codec.11.payload_type = G726-40
+account.2.codec.11.priority = 0
+account.2.codec.11.rtpmap = 105
+
+account.2.codec.12.enable = 0
+account.2.codec.12.payload_type = GSM
+account.2.codec.12.priority = 0
+account.2.codec.12.rtpmap = 3
 
 
 #######################################################################################
-##                         Features Sync                                             ##       
+##                            Audio Advanced                                         ##
 #######################################################################################
-account.1.features.forward.feature_key_sync.local_processing.enable=
-account.1.features.dnd.feature_key_sync.local_processing.enable =
+#Specify whether to encrypt the SIP messages; 0-Disabled (default), 1-Forced, 2-Negotiated;
+account.2.srtp_encryption =
+
+#Configure the RTP packet time. The valid values are 0 (Disabled), 10, 20 (default), 30, 40, 50, 60.
+account.2.ptime =
+
 
 #######################################################################################
-##                                   ACD                                             ##       
+##                            Anonymous Call                                         ##
 #######################################################################################
-account.1.acd.available_url=
-account.1.acd.away_url =
-account.1.acd.refresh_url =
-account.1.acd.call_information=
+account.2.anonymous_call = 0
+account.2.anonymous_call_oncode =
+account.2.anonymous_call_offcode =
 
+account.2.reject_anonymous_call =
+account.2.anonymous_reject_oncode =
+account.2.anonymous_reject_offcode =
+
+#######################################################################################
+##                            Pickup Code                                            ##
+#######################################################################################
+account.2.dialoginfo_callpickup = 0
+
+#Configure the directed and group pickup codes for account 1, the settings on a per-account basis take precedence over the settings on the phone.
+account.2.group_pickup_code =
+account.2.direct_pickup_code =
+
+#######################################################################################
+##                            DTMF                                                   ##
+#######################################################################################
+#Configure the DTMF type; 0-INBAND, 1-RFC2833 (default), 2-SIP INFO, 3-AUTO+SIP INFO;
+account.2.dtmf.type =
+
+#Configure the DTMF info type when using the SIP INFO; 0-Disabled (default), 1-DTMF-Relay, 2-DTMF, 3-Telephone-Event;
+account.2.dtmf.info_type =
+
+#Configure the RFC2833 payload. It ranges from 96 to 255, the default value is 101.
+account.2.dtmf.dtmf_payload =
+
+#######################################################################################
+##                            Alert info                                             ##
+#######################################################################################
+#Enable or disable to use the Distinctive Ring Tones;  0-Disabled , 1-Enabled(default);
+account.2.alert_info_url_enable =
+
+#Assign a ringtone for account2. The system ring tones are: common (default), Ring1.wav - Ring8.wav.
+#If you set the custom ring tone (Busy.wav) for the phone, the value is: account.2.ringtone.ring_type = Config:Busy.wav
+#If you set the system ring tone (Ring2.wav) for the phone, the value is: account.2.ringtone.ring_type = Resource:Ring2.wav
+account.2.ringtone.ring_type =
+
+account.2.picture_info_enable = 1
+
+#######################################################################################
+##                            Conference                                             ##
+#######################################################################################
+#Configure the conference type; 0-Local (default), 2-Network Conference;
+account.2.conf_type =
+
+#Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
+account.2.conf_uri =
+
+#######################################################################################
+##                            cid source                                             ##
+#######################################################################################
+#Configure the type of SIP header(s) to carry the caller ID; 0-FROM (default), 1-PAI 2-PAI-FROM, 3-PRID-PAI-FROM, 4-PAI-RPID-FROM, 5-RPID-FROM;
+account.2.cid_source = {$yealink_cid_source}
+
+account.2.cid_source_privacy = 1
+account.2.cid_source_ppi = 1
+
+#Configure the presentation of the callee ID; 0-PAI-PRID, 1-DIALED DIGITS (default), 2-RFC4916;
+account.2.cp_source = 2
+
+#######################################################################################
+##                            Session Timer                                          ##
+#######################################################################################
+#Enable or disable the session timer, 0-Disabled (default), 1-Enabled;
+account.2.session_timer.enable = {$yealink_session_timer}
+
+#Configure the refresh session timer interval (in seconds). It ranges from 1 to 9999.
+account.2.session_timer.expires =
+
+#Configure the session timer refresher; 0-Uac (default), 1-Uas;
+account.2.session_timer.refresher =
+
+#######################################################################################
+##                            Music on Hold                                          ##
+#######################################################################################
+#Configure the type of Music on Hold; 0-Send the INVITE request to Music on Hold Server then hold the call; 1-Hold the call then send the INVITE request to Music on Hold Server;
+#Require reboot;
+account.2.music_on_hold_type =
+
+account.2.music_server_uri =
+
+#######################################################################################
+##                            Advanced                                               ##
+#######################################################################################
+#Enable or disable the auto answer feature; 0-Disabled (default), 1-Enabled;
+account.2.auto_answer =
+
+#Enable or disable the phone to record the missed call; 0-Disabled, 1-Enabled (default);
+account.2.missed_calllog =
+
+#Enable or disable the 100 reliable retransmission; 0-Disabled (default), 1-Enabled;
+account.2.100rel_enable = {$yealink_retransmission}
+
+#Enable or disable the "user=phone"; 0-Disabled (default), 1-Enabled;
+account.2.enable_user_equal_phone =
+
+#Enable or disable the simplified header field feature; 0-Disabled, 1-Enabled (default);
+account.2.compact_header_enable =
+
+#######################################################################################
+##                                   DND                                             ##
+#######################################################################################
+account.2.dnd.enable =
+account.2.dnd.on_code =
+account.2.dnd.off_code =
+
+#######################################################################################
+##                                 Call Forward                                      ##
+#######################################################################################
+#Enable or disable the busy forward feature for account; 0-Disabled (default), 1-Enabled;
+account.2.always_fwd.enable =
+account.2.always_fwd.target =
+account.2.always_fwd.off_code =
+account.2.always_fwd.on_code =
+
+account.2.busy_fwd.enable =
+account.2.busy_fwd.target =
+account.2.busy_fwd.off_code =
+account.2.busy_fwd.on_code =
+
+#Enable or disable the no answer forward feature for account1; 0-Disabled (default), 1-Enabled;
+#Configure the waiting ring times before forwarding. It ranges from 0 to 20, the default value is 2.
+account.2.timeout_fwd.enable =
+account.2.timeout_fwd.target =
+account.2.timeout_fwd.timeout =
+account.2.timeout_fwd.off_code =
+account.2.timeout_fwd.on_code =
+
+#######################################################################################
+##                                 Broadsoft Hoteling                                ##
+#######################################################################################
+account.2.hoteling.enable = 0
+account.2.hoteling.user_id = 0
+account.2.hoteling.password = 0
+account.2.hoteling.auto_login_enable = 0
+
+#######################################################################################
+##                                 Broadsoft ACD                                     ##
+#######################################################################################
+account.2.acd.enable = 0
+account.2.acd.unavailable_reason_enable = 0
+account.2.acd.available = 0
+account.2.acd.initial_state = 1
+
+#######################################################################################
+##                                 Broadsoft ACD Call Center                         ##
+#######################################################################################
+#Configure the ACD reason code of Broadsoft.(The valus of Y must be consecutive numbers.)
+#account.2.bw_acd_reason_code.Y = 500(lunch time)
+account.2.bw_acd_reason_code.1 =
+
+account.2.reason_code.1 =
+account.2.reason_code_name.1 = 0
+account.2.bw_disp_code.1 =
+account.2.bw_disp_code_name.1 =
+account.2.supervisor_info_code.1 =
+account.2.supervisor_info_code_name.1 =
+
+#######################################################################################
+##                                 Broadsoft Call Center                             ##
+#######################################################################################
+account.2.call_center.call_info_enable = 0
+account.2.call_center.show_call_info_time = 30
+account.2.call_center.disp_code_enable = 0
+account.2.call_center.trace_enable = 0
+account.2.call_center.emergency_enable = 0
+account.2.call_center.queue_status_enable = 0
+account.2.call_center.queue_status_light_enable = 0
+
+#######################################################################################
+##                                 Broadsoft XSI                                     ##
+#######################################################################################
+account.2.xsi.user =
+account.2.xsi.password =
+account.2.xsi.host =
+account.2.xsi.server_type =
+account.2.xsi.port =
+
+
+#######################################################################################
+##                                 Time                                              ##
+#######################################################################################
+#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
+#local_time.time_zone = +8
+#local_time.time_zone_name = China(Beijing)
+local_time.time_zone = {$yealink_time_zone}
+local_time.time_zone_name = {$yealink_time_zone_name}
+
+
+#######################################################################################
+##                                   NETWORK                                         ##
+#######################################################################################
+
+#######################################################################################
+##                           Account 3 Basic Settings                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.enable =
+{if isset($user_password_3) }
+account.3.enable = 1
+{else}
+account.3.enable = 0
+{/if}
+account.3.label = {$display_name_3}
+account.3.display_name = {$display_name_3}
+account.3.auth_name = {$auth_id_3}
+account.3.password = {$user_password_3}
+account.3.user_name = {$user_id_3}
+account.3.sip_server_host = {$server_address_3}
+account.3.sip_server_port = {$sip_port_3}
+account.3.outbound_host = {$outbound_proxy_3}
+
+account.3.outbound_port = {$sip_port_1}
+{if isset($yealink_sip_listen_port)}account.3.sip_listen_port = {$yealink_sip_listen_port}{else}account.3.sip_listen_port = 5060{/if}
+
+account.3.sip_listen_port = 5060
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS SRV;
+{if $sip_transport_3 == 'udp'}account.3.transport = 0{/if}
+{if $sip_transport_3 == 'tcp'}account.3.transport = 1{/if}
+{if $sip_transport_3 == 'tls'}account.3.transport = 2{/if}
+{if $sip_transport_3 == 'dns srv'}account.3.transport = 3{/if}
+
+account.3.outbound_proxy.1.address = {$outbound_proxy_primary_3}
+account.3.outbound_proxy.2.address = {$outbound_proxy_secondary_3}
+account.3.outbound_proxy_enable = {if isset($outbound_proxy_primary_3)}1{else}0{/if}
+
+#######################################################################################
+##                          Failback                                                 ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.reregister_enable = 0
+
+account.3.reregister_enable = 0
+account.3.retry_counts =
+account.3.failback_mode = 0
+account.3.failback_timeout = 3600
+account.3.naptr_build = 0
+account.3.fallback.redundancy_type = 0
+account.3.fallback.timeout = {$yealink_outbound_proxy_fallback_interval}
+account.3.sip_server.1.address =
+account.3.sip_server.1.port = 5060
+#Configure the register expiry time (in seconds), the default value is 3600.
+account.3.sip_server.1.expires = {$register_expires_3}
+account.3.sip_server.1.retry_counts = 3
+account.3.sip_server.1.failback_mode = 0
+account.3.sip_server.1.failback_timeout = 3600
+account.3.sip_server.1.register_on_enable = 0
+account.3.sip_server.2.address =
+account.3.sip_server.2.port = 5060
+account.3.sip_server.2.expires = 3600
+account.3.sip_server.2.retry_counts = 3
+account.3.sip_server.2.failback_mode = 0
+account.3.sip_server.2.failback_timeout = 3600
+account.3.sip_server.2.register_on_enable = 0
+account.3.dns_cache_type = 1
+
+account.3.dns_cache_a.1.name =
+account.3.dns_cache_a.1.ip =
+account.3.dns_cache_a.1.ttl = 300
+
+account.3.dns_cache_srv.0.name =
+account.3.dns_cache_srv.0.port = 0
+account.3.dns_cache_srv.0.priority = 0
+account.3.dns_cache_srv.0.target =
+account.3.dns_cache_srv.0.weight = 0
+account.3.dns_cache_srv.0.ttl = 300
+account.3.dns_cache_naptr.0.name =
+account.3.dns_cache_naptr.0.flags =
+account.3.dns_cache_naptr.0.order = 0
+account.3.dns_cache_naptr.0.preference = 0
+account.3.dns_cache_naptr.0.replace =
+account.3.dns_cache_naptr.0.service =
+account.3.dns_cache_naptr.0.ttl = 300
+
+account.3.static_cache_pri = 0
+
+#######################################################################################
+##                           Register Advanced                                       ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.sip_server_type =
+
+#Configure the SIP server type; 0-Default (default), 2-BroadSoft, 4-Cosmocom;
+account.3.sip_server_type =
+#Enable or disable the phone to send the account log-off message first and then send account register message when rebooting the phone; 0-Disabled (default), 1-Enabled;
+account.3.unregister_on_reboot =
+
+#Enable or disable the phone to only accept the message from the server; 0-Disabled (default), 1-Enabled;
+account.3.sip_trust_ctrl = 1
+
+#Configure the timeout (in seconds) for DNS query, the value ranges from 1 to 9, the default value is 8.
+account.3.dns_query_timeout=
+
+#Enable or disable the timer to periodically refresh the DNS-SRV query result; 0-Disabled (default), 1-Enabled;
+account.3.srv_ttl_timer_enable =
+account.3.proxy_require =
+
+
+#Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
+account.3.register_mac =
+account.3.register_line =
+
+#Configure the interval (in seconds) the phone retries to register when account1 fails to register. It ranges from 0 to 1800, the default value is 30.
+account.3.reg_fail_retry_interval =
+
+#########################################################################
+##                     NAT Settings                                    ##
+#########################################################################
+
+#Enable or disable the NAT traversal; 0-Disabled (default), 1-STUN;
+account.3.nat.nat_traversal = {if isset($stun_server)}1{else}0{/if}
+
+#Configure the STUN server address.
+account.3.nat.stun_server = {$stun_server}
+
+#Configure the STUN server port, the default value is 3478.
+account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
+
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.3.nat.udp_update_enable = 1
+
+#Specify the keep-alive interval (in seconds), the default value is 30.
+account.3.nat.udp_update_time = 30
+
+#Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
+account.3.nat.rport = {$yealink_rport}
+
+
+#######################################################################################
+##                            Account3 Advance Settings                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.advanced.timer_t1 = 0.5
+##voice_mail.number.X =
+
+#Configure the session timer (in seconds), the default value of T1, T2, T3 is 0.5, 4, 5.
+account.3.advanced.timer_t1 = 0.5
+account.3.advanced.timer_t2 = 4
+account.3.advanced.timer_t4 = 5
+
+voice_mail.number.3 = *97
+
+
+#######################################################################################
+##                            Subscribe                                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.subscribe_mwi =
+
+account.3.subscribe_mwi = 1
+account.3.subscribe_mwi_expires = 3600
+
+#Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
+
+account.3.subscribe_acd_expires= 3600
+
+
+#######################################################################################
+##                            BLF List                                               ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.blf.blf_list_uri =
+
+#Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
+account.3.blf.blf_list_uri =
+
+account.3.blf_list_code =
+account.3.blf_list_barge_in_code =
+account.3.blf.subscribe_period = 1800
+
+account.3.blf.subscribe_event =
+account.3.out_dialog_blf_enable = 0
+
+
+#######################################################################################
+##                            BLA/SCA                                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.shared_line =
+
+#Assign account1 as shared line; 0-Disabled (default), 1-Broadsoft SCA, 2-BLA;
+{if isset($shared_line_3) }
+account.3.shared_line = {$shared_line_3}
+{else}
+account.3.shared_line = 0
+{/if}
+
+#Configure BLA number for account1 and the subscribe period (in seconds). It ranges from 60 to 7200, the default value is 300.
+account.3.bla_number =
+account.3.bla_subscribe_period = 300
+
+#######################################################################################
+##                            Audio Codec                                            ##
+#######################################################################################
+#Audio codecs for account1 (Y ranges from 1 to 11).
+#Enable or disable the specified codec; 0-Disabled, 1-Enabled;
+#account.3.codec.Y.enable =
+#The type of the specified codec.
+#account.3.codec.Y.payload_type =
+#The priority of the specified codec. It's available when the codec is enabled.
+#account.3.codec.Y.priority =
+#The payload of the specified codec.
+#account.3.codec.Y.rtpmap =
+
+account.3.codec.1.enable = 1
+account.3.codec.1.payload_type = PCMU
+account.3.codec.1.priority = 2
+account.3.codec.1.rtpmap = 0
+
+account.3.codec.2.enable = 1
+account.3.codec.2.payload_type = PCMA
+account.3.codec.2.priority = 3
+account.3.codec.2.rtpmap = 8
+
+account.3.codec.3.enable = 0
+account.3.codec.3.payload_type = G723_53
+account.3.codec.3.priority =0
+account.3.codec.3.rtpmap = 4
+
+account.3.codec.4.enable = 0
+account.3.codec.4.payload_type = G723_63
+account.3.codec.4.priority = 0
+account.3.codec.4.rtpmap = 4
+
+account.3.codec.5.enable = 1
+account.3.codec.5.payload_type = G729
+account.3.codec.5.priority = 3
+account.3.codec.5.rtpmap = 18
+
+account.3.codec.6.enable = 1
+account.3.codec.6.payload_type = G722
+account.3.codec.6.priority = 1
+account.3.codec.6.rtpmap = 9
+
+account.3.codec.7.enable = 0
+account.3.codec.7.payload_type = iLBC
+account.3.codec.7.priority =  0
+account.3.codec.7.rtpmap = 106
+
+account.3.codec.8.enable = 0
+account.3.codec.8.payload_type = G726-16
+account.3.codec.8.priority = 0
+account.3.codec.8.rtpmap = 103
+
+account.3.codec.9.enable = 0
+account.3.codec.9.payload_type = G726-24
+account.3.codec.9.priority = 0
+account.3.codec.9.rtpmap = 104
+
+account.3.codec.10.enable = 0
+account.3.codec.10.payload_type = G726-32
+account.3.codec.10.priority = 0
+account.3.codec.10.rtpmap = 102
+
+account.3.codec.11.enable = 0
+account.3.codec.11.payload_type = G726-40
+account.3.codec.11.priority = 0
+account.3.codec.11.rtpmap = 105
+
+account.3.codec.12.enable = 0
+account.3.codec.12.payload_type = GSM
+account.3.codec.12.priority = 0
+account.3.codec.12.rtpmap = 3
+
+
+#######################################################################################
+##                            Audio Advanced                                         ##
+#######################################################################################
+#Specify whether to encrypt the SIP messages; 0-Disabled (default), 1-Forced, 2-Negotiated;
+account.3.srtp_encryption =
+
+#Configure the RTP packet time. The valid values are 0 (Disabled), 10, 20 (default), 30, 40, 50, 60.
+account.3.ptime =
+
+
+#######################################################################################
+##                            Anonymous Call                                         ##
+#######################################################################################
+account.3.anonymous_call = 0
+account.3.anonymous_call_oncode =
+account.3.anonymous_call_offcode =
+
+account.3.reject_anonymous_call =
+account.3.anonymous_reject_oncode =
+account.3.anonymous_reject_offcode =
+
+#######################################################################################
+##                            Pickup Code                                            ##
+#######################################################################################
+account.3.dialoginfo_callpickup = 0
+
+#Configure the directed and group pickup codes for account 1, the settings on a per-account basis take precedence over the settings on the phone.
+account.3.group_pickup_code =
+account.3.direct_pickup_code =
+
+#######################################################################################
+##                            DTMF                                                   ##
+#######################################################################################
+#Configure the DTMF type; 0-INBAND, 1-RFC2833 (default), 2-SIP INFO, 3-AUTO+SIP INFO;
+account.3.dtmf.type =
+
+#Configure the DTMF info type when using the SIP INFO; 0-Disabled (default), 1-DTMF-Relay, 2-DTMF, 3-Telephone-Event;
+account.3.dtmf.info_type =
+
+#Configure the RFC2833 payload. It ranges from 96 to 255, the default value is 101.
+account.3.dtmf.dtmf_payload =
+
+#######################################################################################
+##                            Alert info                                             ##
+#######################################################################################
+#Enable or disable to use the Distinctive Ring Tones;  0-Disabled , 1-Enabled(default);
+account.3.alert_info_url_enable =
+
+#Assign a ringtone for account2. The system ring tones are: common (default), Ring1.wav - Ring8.wav.
+#If you set the custom ring tone (Busy.wav) for the phone, the value is: account.2.ringtone.ring_type = Config:Busy.wav
+#If you set the system ring tone (Ring2.wav) for the phone, the value is: account.2.ringtone.ring_type = Resource:Ring2.wav
+account.3.ringtone.ring_type =
+
+account.3.picture_info_enable = 1
+
+#######################################################################################
+##                            Conference                                             ##
+#######################################################################################
+#Configure the conference type; 0-Local (default), 2-Network Conference;
+account.3.conf_type =
+
+#Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
+account.3.conf_uri =
+
+#######################################################################################
+##                            cid source                                             ##
+#######################################################################################
+#Configure the type of SIP header(s) to carry the caller ID; 0-FROM (default), 1-PAI 2-PAI-FROM, 3-PRID-PAI-FROM, 4-PAI-RPID-FROM, 5-RPID-FROM;
+account.3.cid_source = {$yealink_cid_source}
+
+account.3.cid_source_privacy = 1
+account.3.cid_source_ppi = 1
+
+#Configure the presentation of the callee ID; 0-PAI-PRID, 1-DIALED DIGITS (default), 2-RFC4916;
+account.3.cp_source = 2
+
+#######################################################################################
+##                            Session Timer                                          ##
+#######################################################################################
+#Enable or disable the session timer, 0-Disabled (default), 1-Enabled;
+account.3.session_timer.enable = {$yealink_session_timer}
+
+#Configure the refresh session timer interval (in seconds). It ranges from 1 to 9999.
+account.3.session_timer.expires =
+
+#Configure the session timer refresher; 0-Uac (default), 1-Uas;
+account.3.session_timer.refresher =
+
+#######################################################################################
+##                            Music on Hold                                          ##
+#######################################################################################
+#Configure the type of Music on Hold; 0-Send the INVITE request to Music on Hold Server then hold the call; 1-Hold the call then send the INVITE request to Music on Hold Server;
+#Require reboot;
+account.3.music_on_hold_type =
+
+account.3.music_server_uri =
+
+#######################################################################################
+##                            Advanced                                               ##
+#######################################################################################
+#Enable or disable the auto answer feature; 0-Disabled (default), 1-Enabled;
+account.3.auto_answer =
+
+#Enable or disable the phone to record the missed call; 0-Disabled, 1-Enabled (default);
+account.3.missed_calllog =
+
+#Enable or disable the 100 reliable retransmission; 0-Disabled (default), 1-Enabled;
+account.3.100rel_enable = {$yealink_retransmission}
+
+#Enable or disable the "user=phone"; 0-Disabled (default), 1-Enabled;
+account.3.enable_user_equal_phone =
+
+#Enable or disable the simplified header field feature; 0-Disabled, 1-Enabled (default);
+account.3.compact_header_enable =
+
+#######################################################################################
+##                                   DND                                             ##
+#######################################################################################
+account.3.dnd.enable =
+account.3.dnd.on_code =
+account.3.dnd.off_code =
+
+#######################################################################################
+##                                 Call Forward                                      ##
+#######################################################################################
+#Enable or disable the busy forward feature for account; 0-Disabled (default), 1-Enabled;
+account.3.always_fwd.enable =
+account.3.always_fwd.target =
+account.3.always_fwd.off_code =
+account.3.always_fwd.on_code =
+
+account.3.busy_fwd.enable =
+account.3.busy_fwd.target =
+account.3.busy_fwd.off_code =
+account.3.busy_fwd.on_code =
+
+#Enable or disable the no answer forward feature for account1; 0-Disabled (default), 1-Enabled;
+#Configure the waiting ring times before forwarding. It ranges from 0 to 20, the default value is 2.
+account.3.timeout_fwd.enable =
+account.3.timeout_fwd.target =
+account.3.timeout_fwd.timeout =
+account.3.timeout_fwd.off_code =
+account.3.timeout_fwd.on_code =
+
+#######################################################################################
+##                                 Broadsoft Hoteling                                ##
+#######################################################################################
+account.3.hoteling.enable = 0
+account.3.hoteling.user_id = 0
+account.3.hoteling.password = 0
+account.3.hoteling.auto_login_enable = 0
+
+#######################################################################################
+##                                 Broadsoft ACD                                     ##
+#######################################################################################
+account.3.acd.enable = 0
+account.3.acd.unavailable_reason_enable = 0
+account.3.acd.available = 0
+account.3.acd.initial_state = 1
+
+#######################################################################################
+##                                 Broadsoft ACD Call Center                         ##
+#######################################################################################
+#Configure the ACD reason code of Broadsoft.(The valus of Y must be consecutive numbers.)
+#account.3.bw_acd_reason_code.Y = 500(lunch time)
+account.3.bw_acd_reason_code.1 =
+
+account.3.reason_code.1 =
+account.3.reason_code_name.1 = 0
+account.3.bw_disp_code.1 =
+account.3.bw_disp_code_name.1 =
+account.3.supervisor_info_code.1 =
+account.3.supervisor_info_code_name.1 =
+
+#######################################################################################
+##                                 Broadsoft Call Center                             ##
+#######################################################################################
+account.3.call_center.call_info_enable = 0
+account.3.call_center.show_call_info_time = 30
+account.3.call_center.disp_code_enable = 0
+account.3.call_center.trace_enable = 0
+account.3.call_center.emergency_enable = 0
+account.3.call_center.queue_status_enable = 0
+account.3.call_center.queue_status_light_enable = 0
+
+#######################################################################################
+##                                 Broadsoft XSI                                     ##
+#######################################################################################
+account.3.xsi.user =
+account.3.xsi.password =
+account.3.xsi.host =
+account.3.xsi.server_type =
+account.3.xsi.port =
+
+
+#######################################################################################
+##                                   NETWORK                                         ##
+#######################################################################################
+
+#######################################################################################
+##                           Account 4 Basic Settings                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.enable =
+{if isset($user_password_4) }
+account.4.enable = 1
+{else}
+account.4.enable = 0
+{/if}
+account.4.label = {$display_name_4}
+account.4.display_name = {$display_name_4}
+account.4.auth_name = {$auth_id_4}
+account.4.password = {$user_password_4}
+account.4.user_name = {$user_id_4}
+account.4.sip_server_host = {$server_address_4}
+account.4.sip_server_port = {$sip_port_4}
+account.4.outbound_host = {$outbound_proxy_4}
+
+account.4.outbound_port = {$sip_port_1}
+{if isset($yealink_sip_listen_port)}account.4.sip_listen_port = {$yealink_sip_listen_port}{else}account.4.sip_listen_port = 5060{/if}
+
+account.4.sip_listen_port = 5060
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS SRV;
+{if $sip_transport_4 == 'udp'}account.4.transport = 0{/if}
+{if $sip_transport_4 == 'tcp'}account.4.transport = 1{/if}
+{if $sip_transport_4 == 'tls'}account.4.transport = 2{/if}
+{if $sip_transport_4 == 'dns srv'}account.4.transport = 3{/if}
+
+account.4.outbound_proxy.1.address = {$outbound_proxy_primary_4}
+account.4.outbound_proxy.2.address = {$outbound_proxy_secondary_4}
+account.4.outbound_proxy_enable = {if isset($outbound_proxy_primary_4)}1{else}0{/if}
+
+#######################################################################################
+##                          Failback                                                 ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.reregister_enable = 0
+
+account.4.reregister_enable = 0
+account.4.retry_counts =
+account.4.failback_mode = 0
+account.4.failback_timeout = 3600
+account.4.naptr_build = 0
+account.4.fallback.redundancy_type = 0
+account.4.fallback.timeout = {$yealink_outbound_proxy_fallback_interval}
+account.4.sip_server.1.address =
+account.4.sip_server.1.port = 5060
+#Configure the register expiry time (in seconds), the default value is 3600.
+account.4.sip_server.1.expires = {$register_expires_4}
+account.4.sip_server.1.retry_counts = 3
+account.4.sip_server.1.failback_mode = 0
+account.4.sip_server.1.failback_timeout = 3600
+account.4.sip_server.1.register_on_enable = 0
+account.4.sip_server.2.address =
+account.4.sip_server.2.port = 5060
+account.4.sip_server.2.expires = 3600
+account.4.sip_server.2.retry_counts = 3
+account.4.sip_server.2.failback_mode = 0
+account.4.sip_server.2.failback_timeout = 3600
+account.4.sip_server.2.register_on_enable = 0
+account.4.dns_cache_type = 1
+
+account.4.dns_cache_a.1.name =
+account.4.dns_cache_a.1.ip =
+account.4.dns_cache_a.1.ttl = 300
+
+account.4.dns_cache_srv.1.name =
+account.4.dns_cache_srv.1.port = 0
+account.4.dns_cache_srv.1.priority = 0
+account.4.dns_cache_srv.1.target =
+account.4.dns_cache_srv.1.weight = 0
+account.4.dns_cache_srv.1.ttl = 300
+account.4.dns_cache_naptr.1.name =
+account.4.dns_cache_naptr.1.flags =
+account.4.dns_cache_naptr.1.order = 0
+account.4.dns_cache_naptr.1.preference = 0
+account.4.dns_cache_naptr.1.replace =
+account.4.dns_cache_naptr.1.service =
+account.4.dns_cache_naptr.1.ttl = 300
+
+account.4.static_cache_pri = 0
+
+#######################################################################################
+##                           Register Advanced                                       ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.sip_server_type =
+
+#Configure the SIP server type; 0-Default (default), 2-BroadSoft, 4-Cosmocom;
+account.4.sip_server_type =
+#Enable or disable the phone to send the account log-off message first and then send account register message when rebooting the phone; 0-Disabled (default), 1-Enabled;
+account.4.unregister_on_reboot =
+
+#Enable or disable the phone to only accept the message from the server; 0-Disabled (default), 1-Enabled;
+account.4.sip_trust_ctrl = 1
+
+#Configure the timeout (in seconds) for DNS query, the value ranges from 1 to 9, the default value is 8.
+account.4.dns_query_timeout=
+
+#Enable or disable the timer to periodically refresh the DNS-SRV query result; 0-Disabled (default), 1-Enabled;
+account.4.srv_ttl_timer_enable =
+account.4.proxy_require =
+
+
+#Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
+account.4.register_mac =
+account.4.register_line =
+
+#Configure the interval (in seconds) the phone retries to register when account1 fails to register. It ranges from 0 to 1800, the default value is 30.
+account.4.reg_fail_retry_interval =
+
+#########################################################################
+##                     NAT Settings                                    ##
+#########################################################################
+
+#Enable or disable the NAT traversal; 0-Disabled (default), 1-STUN;
+account.4.nat.nat_traversal = {if isset($stun_server)}1{else}0{/if}
+
+#Configure the STUN server address.
+account.4.nat.stun_server = {$stun_server}
+
+#Configure the STUN server port, the default value is 3478.
+account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
+
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.4.nat.udp_update_enable = 1
+
+#Specify the keep-alive interval (in seconds), the default value is 30.
+account.4.nat.udp_update_time = 30
+
+#Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
+account.4.nat.rport = {$yealink_rport}
+
+
+#######################################################################################
+##                            Account4 Advance Settings                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.advanced.timer_t1 = 0.5
+##voice_mail.number.X =
+
+#Configure the session timer (in seconds), the default value of T1, T2, T3 is 0.5, 4, 5.
+account.4.advanced.timer_t1 = 0.5
+account.4.advanced.timer_t2 = 4
+account.4.advanced.timer_t4 = 5
+
+voice_mail.number.4 = *97
+
+
+#######################################################################################
+##                            Subscribe                                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.subscribe_mwi =
+
+account.4.subscribe_mwi = 1
+account.4.subscribe_mwi_expires = 3600
+
+#Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
+
+account.4.subscribe_acd_expires= 3600
+
+
+#######################################################################################
+##                            BLF List                                               ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.blf.blf_list_uri =
+
+#Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
+account.4.blf.blf_list_uri =
+
+account.4.blf_list_code =
+account.4.blf_list_barge_in_code =
+account.4.blf.subscribe_period = 1800
+
+account.4.blf.subscribe_event =
+account.4.out_dialog_blf_enable = 0
+
+
+#######################################################################################
+##                            BLA/SCA                                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.shared_line =
+
+#Assign account1 as shared line; 0-Disabled (default), 1-Broadsoft SCA, 2-BLA;
+{if isset($shared_line_4) }
+account.4.shared_line = {$shared_line_4}
+{else}
+account.4.shared_line = 0
+{/if}
+
+#Configure BLA number for account1 and the subscribe period (in seconds). It ranges from 60 to 7200, the default value is 300.
+account.4.bla_number =
+account.4.bla_subscribe_period = 300
+
+#######################################################################################
+##                            Audio Codec                                            ##
+#######################################################################################
+#Audio codecs for account1 (Y ranges from 1 to 11).
+#Enable or disable the specified codec; 0-Disabled, 1-Enabled;
+#account.4.codec.Y.enable =
+#The type of the specified codec.
+#account.4.codec.Y.payload_type =
+#The priority of the specified codec. It's available when the codec is enabled.
+#account.4.codec.Y.priority =
+#The payload of the specified codec.
+#account.4.codec.Y.rtpmap =
+
+account.4.codec.1.enable = 1
+account.4.codec.1.payload_type = PCMU
+account.4.codec.1.priority = 1
+account.4.codec.1.rtpmap = 0
+
+account.4.codec.2.enable = 1
+account.4.codec.2.payload_type = PCMA
+account.4.codec.2.priority = 2
+account.4.codec.2.rtpmap = 8
+
+account.4.codec.3.enable = 0
+account.4.codec.3.payload_type = G723_53
+account.4.codec.3.priority =0
+account.4.codec.3.rtpmap = 4
+
+account.4.codec.4.enable = 0
+account.4.codec.4.payload_type = G723_63
+account.4.codec.4.priority = 0
+account.4.codec.4.rtpmap = 4
+
+account.4.codec.5.enable = 1
+account.4.codec.5.payload_type = G729
+account.4.codec.5.priority = 3
+account.4.codec.5.rtpmap = 18
+
+account.4.codec.6.enable = 1
+account.4.codec.6.payload_type = G722
+account.4.codec.6.priority = 4
+account.4.codec.6.rtpmap = 9
+
+account.4.codec.7.enable = 0
+account.4.codec.7.payload_type = iLBC
+account.4.codec.7.priority =  0
+account.4.codec.7.rtpmap = 106
+
+account.4.codec.8.enable = 0
+account.4.codec.8.payload_type = G726-16
+account.4.codec.8.priority = 0
+account.4.codec.8.rtpmap = 103
+
+account.4.codec.9.enable = 0
+account.4.codec.9.payload_type = G726-24
+account.4.codec.9.priority = 0
+account.4.codec.9.rtpmap = 104
+
+account.4.codec.10.enable = 0
+account.4.codec.10.payload_type = G726-32
+account.4.codec.10.priority = 0
+account.4.codec.10.rtpmap = 102
+
+account.4.codec.11.enable = 0
+account.4.codec.11.payload_type = G726-40
+account.4.codec.11.priority = 0
+account.4.codec.11.rtpmap = 105
+
+account.4.codec.12.enable = 0
+account.4.codec.12.payload_type = GSM
+account.4.codec.12.priority = 0
+account.4.codec.12.rtpmap = 3
+
+
+#######################################################################################
+##                            Audio Advanced                                         ##
+#######################################################################################
+#Specify whether to encrypt the SIP messages; 0-Disabled (default), 1-Forced, 2-Negotiated;
+account.4.srtp_encryption =
+
+#Configure the RTP packet time. The valid values are 0 (Disabled), 10, 20 (default), 30, 40, 50, 60.
+account.4.ptime =
+
+
+#######################################################################################
+##                            Anonymous Call                                         ##
+#######################################################################################
+account.4.anonymous_call = 0
+account.4.anonymous_call_oncode =
+account.4.anonymous_call_offcode =
+
+account.4.reject_anonymous_call =
+account.4.anonymous_reject_oncode =
+account.4.anonymous_reject_offcode =
+
+#######################################################################################
+##                            Pickup Code                                            ##
+#######################################################################################
+account.4.dialoginfo_callpickup = 0
+
+#Configure the directed and group pickup codes for account 1, the settings on a per-account basis take precedence over the settings on the phone.
+account.4.group_pickup_code =
+account.4.direct_pickup_code =
+
+#######################################################################################
+##                            DTMF                                                   ##
+#######################################################################################
+#Configure the DTMF type; 0-INBAND, 1-RFC2833 (default), 2-SIP INFO, 3-AUTO+SIP INFO;
+account.4.dtmf.type =
+
+#Configure the DTMF info type when using the SIP INFO; 0-Disabled (default), 1-DTMF-Relay, 2-DTMF, 3-Telephone-Event;
+account.4.dtmf.info_type =
+
+#Configure the RFC2833 payload. It ranges from 96 to 255, the default value is 101.
+account.4.dtmf.dtmf_payload =
+
+#######################################################################################
+##                            Alert info                                             ##
+#######################################################################################
+#Enable or disable to use the Distinctive Ring Tones;  0-Disabled , 1-Enabled(default);
+account.4.alert_info_url_enable =
+
+#Assign a ringtone for account2. The system ring tones are: common (default), Ring1.wav - Ring8.wav.
+#If you set the custom ring tone (Busy.wav) for the phone, the value is: account.2.ringtone.ring_type = Config:Busy.wav
+#If you set the system ring tone (Ring2.wav) for the phone, the value is: account.2.ringtone.ring_type = Resource:Ring2.wav
+account.4.ringtone.ring_type =
+
+account.4.picture_info_enable = 1
+
+#######################################################################################
+##                            Conference                                             ##
+#######################################################################################
+#Configure the conference type; 0-Local (default), 2-Network Conference;
+account.4.conf_type =
+
+#Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
+account.4.conf_uri =
+
+#######################################################################################
+##                            cid source                                             ##
+#######################################################################################
+#Configure the type of SIP header(s) to carry the caller ID; 0-FROM (default), 1-PAI 2-PAI-FROM, 3-PRID-PAI-FROM, 4-PAI-RPID-FROM, 5-RPID-FROM;
+account.4.cid_source = {$yealink_cid_source}
+
+account.4.cid_source_privacy = 1
+account.4.cid_source_ppi = 1
+
+#Configure the presentation of the callee ID; 0-PAI-PRID, 1-DIALED DIGITS (default), 2-RFC4916;
+account.4.cp_source = 2
+
+#######################################################################################
+##                            Session Timer                                          ##
+#######################################################################################
+#Enable or disable the session timer, 0-Disabled (default), 1-Enabled;
+account.4.session_timer.enable = {$yealink_session_timer}
+
+#Configure the refresh session timer interval (in seconds). It ranges from 1 to 9999.
+account.4.session_timer.expires =
+
+#Configure the session timer refresher; 0-Uac (default), 1-Uas;
+account.4.session_timer.refresher =
+
+#######################################################################################
+##                            Music on Hold                                          ##
+#######################################################################################
+#Configure the type of Music on Hold; 0-Send the INVITE request to Music on Hold Server then hold the call; 1-Hold the call then send the INVITE request to Music on Hold Server;
+#Require reboot;
+account.4.music_on_hold_type =
+
+account.4.music_server_uri =
+
+#######################################################################################
+##                            Advanced                                               ##
+#######################################################################################
+#Enable or disable the auto answer feature; 0-Disabled (default), 1-Enabled;
+account.4.auto_answer =
+
+#Enable or disable the phone to record the missed call; 0-Disabled, 1-Enabled (default);
+account.4.missed_calllog =
+
+#Enable or disable the 100 reliable retransmission; 0-Disabled (default), 1-Enabled;
+account.4.100rel_enable = {$yealink_retransmission}
+
+#Enable or disable the "user=phone"; 0-Disabled (default), 1-Enabled;
+account.4.enable_user_equal_phone =
+
+#Enable or disable the simplified header field feature; 0-Disabled, 1-Enabled (default);
+account.4.compact_header_enable =
+
+#######################################################################################
+##                                   DND                                             ##
+#######################################################################################
+account.4.dnd.enable =
+account.4.dnd.on_code =
+account.4.dnd.off_code =
+
+#######################################################################################
+##                                 Call Forward                                      ##
+#######################################################################################
+#Enable or disable the busy forward feature for account; 0-Disabled (default), 1-Enabled;
+account.4.always_fwd.enable =
+account.4.always_fwd.target =
+account.4.always_fwd.off_code =
+account.4.always_fwd.on_code =
+
+account.4.busy_fwd.enable =
+account.4.busy_fwd.target =
+account.4.busy_fwd.off_code =
+account.4.busy_fwd.on_code =
+
+#Enable or disable the no answer forward feature for account1; 0-Disabled (default), 1-Enabled;
+#Configure the waiting ring times before forwarding. It ranges from 0 to 20, the default value is 2.
+account.4.timeout_fwd.enable =
+account.4.timeout_fwd.target =
+account.4.timeout_fwd.timeout =
+account.4.timeout_fwd.off_code =
+account.4.timeout_fwd.on_code =
+
+#######################################################################################
+##                                 Broadsoft Hoteling                                ##
+#######################################################################################
+account.4.hoteling.enable = 0
+account.4.hoteling.user_id = 0
+account.4.hoteling.password = 0
+account.4.hoteling.auto_login_enable = 0
+
+#######################################################################################
+##                                 Broadsoft ACD                                     ##
+#######################################################################################
+account.4.acd.enable = 0
+account.4.acd.unavailable_reason_enable = 0
+account.4.acd.available = 0
+account.4.acd.initial_state = 1
+
+#######################################################################################
+##                                 Broadsoft ACD Call Center                         ##
+#######################################################################################
+#Configure the ACD reason code of Broadsoft.(The valus of Y must be consecutive numbers.)
+#account.4.bw_acd_reason_code.Y = 500(lunch time)
+account.4.bw_acd_reason_code.1 =
+
+account.4.reason_code.1 =
+account.4.reason_code_name.1 = 0
+account.4.bw_disp_code.1 =
+account.4.bw_disp_code_name.1 =
+account.4.supervisor_info_code.1 =
+account.4.supervisor_info_code_name.1 =
+
+#######################################################################################
+##                                 Broadsoft Call Center                             ##
+#######################################################################################
+account.4.call_center.call_info_enable = 0
+account.4.call_center.show_call_info_time = 30
+account.4.call_center.disp_code_enable = 0
+account.4.call_center.trace_enable = 0
+account.4.call_center.emergency_enable = 0
+account.4.call_center.queue_status_enable = 0
+account.4.call_center.queue_status_light_enable = 0
+
+#######################################################################################
+##                                 Broadsoft XSI                                     ##
+#######################################################################################
+account.4.xsi.user =
+account.4.xsi.password =
+account.4.xsi.host =
+account.4.xsi.server_type =
+account.4.xsi.port =
+
+
+#######################################################################################
+##                                   NETWORK                                         ##
+#######################################################################################
+
+#######################################################################################
+##                           Account 5 Basic Settings                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.enable =
+{if isset($user_password_5) }
+account.5.enable = 1
+{else}
+account.5.enable = 0
+{/if}
+account.5.label = {$display_name_5}
+account.5.display_name = {$display_name_5}
+account.5.auth_name = {$auth_id_5}
+account.5.password = {$user_password_5}
+account.5.user_name = {$user_id_5}
+account.5.sip_server_host = {$server_address_5}
+account.5.sip_server_port = {$sip_port_5}
+account.5.outbound_host = {$outbound_proxy_5}
+
+account.5.outbound_port = {$sip_port_1}
+{if isset($yealink_sip_listen_port)}account.5.sip_listen_port = {$yealink_sip_listen_port}{else}account.5.sip_listen_port = 5060{/if}
+
+account.5.sip_listen_port = 5060
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS SRV;
+{if $sip_transport_5 == 'udp'}account.5.transport = 0{/if}
+{if $sip_transport_5 == 'tcp'}account.5.transport = 1{/if}
+{if $sip_transport_5 == 'tls'}account.5.transport = 2{/if}
+{if $sip_transport_5 == 'dns srv'}account.5.transport = 3{/if}
+
+account.5.outbound_proxy.1.address = {$outbound_proxy_primary_5}
+account.5.outbound_proxy.2.address = {$outbound_proxy_secondary_5}
+account.5.outbound_proxy_enable = {if isset($outbound_proxy_primary_5)}1{else}0{/if}
+
+#######################################################################################
+##                          Failback                                                 ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.reregister_enable = 0
+
+account.5.reregister_enable = 0
+account.5.retry_counts =
+account.5.failback_mode = 0
+account.5.failback_timeout = 3600
+account.5.naptr_build = 0
+account.5.fallback.redundancy_type = 0
+account.5.fallback.timeout = {$yealink_outbound_proxy_fallback_interval}
+account.5.sip_server.1.address =
+account.5.sip_server.1.port = 5060
+#Configure the register expiry time (in seconds), the default value is 3600.
+account.5.sip_server.1.expires = {$register_expires_5}
+account.5.sip_server.1.retry_counts = 3
+account.5.sip_server.1.failback_mode = 0
+account.5.sip_server.1.failback_timeout = 3600
+account.5.sip_server.1.register_on_enable = 0
+account.5.sip_server.2.address =
+account.5.sip_server.2.port = 5060
+account.5.sip_server.2.expires = 3600
+account.5.sip_server.2.retry_counts = 3
+account.5.sip_server.2.failback_mode = 0
+account.5.sip_server.2.failback_timeout = 3600
+account.5.sip_server.2.register_on_enable = 0
+account.5.dns_cache_type = 1
+
+account.5.dns_cache_a.1.name =
+account.5.dns_cache_a.1.ip =
+account.5.dns_cache_a.1.ttl = 300
+
+account.5.dns_cache_srv.1.name =
+account.5.dns_cache_srv.1.port = 0
+account.5.dns_cache_srv.1.priority = 0
+account.5.dns_cache_srv.1.target =
+account.5.dns_cache_srv.1.weight = 0
+account.5.dns_cache_srv.1.ttl = 300
+account.5.dns_cache_naptr.1.name =
+account.5.dns_cache_naptr.1.flags =
+account.5.dns_cache_naptr.1.order = 0
+account.5.dns_cache_naptr.1.preference = 0
+account.5.dns_cache_naptr.1.replace =
+account.5.dns_cache_naptr.1.service =
+account.5.dns_cache_naptr.1.ttl = 300
+
+account.5.static_cache_pri = 0
+
+#######################################################################################
+##                           Register Advanced                                       ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.sip_server_type =
+
+#Configure the SIP server type; 0-Default (default), 2-BroadSoft, 4-Cosmocom;
+account.5.sip_server_type =
+#Enable or disable the phone to send the account log-off message first and then send account register message when rebooting the phone; 0-Disabled (default), 1-Enabled;
+account.5.unregister_on_reboot =
+
+#Enable or disable the phone to only accept the message from the server; 0-Disabled (default), 1-Enabled;
+account.5.sip_trust_ctrl = 1
+
+#Configure the timeout (in seconds) for DNS query, the value ranges from 1 to 9, the default value is 8.
+account.5.dns_query_timeout=
+
+#Enable or disable the timer to periodically refresh the DNS-SRV query result; 0-Disabled (default), 1-Enabled;
+account.5.srv_ttl_timer_enable =
+account.5.proxy_require =
+
+
+#Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
+account.5.register_mac =
+account.5.register_line =
+
+#Configure the interval (in seconds) the phone retries to register when account1 fails to register. It ranges from 0 to 1800, the default value is 30.
+account.5.reg_fail_retry_interval =
+
+#########################################################################
+##                     NAT Settings                                    ##
+#########################################################################
+
+#Enable or disable the NAT traversal; 0-Disabled (default), 1-STUN;
+account.5.nat.nat_traversal = {if isset($stun_server)}1{else}0{/if}
+
+#Configure the STUN server address.
+account.5.nat.stun_server = {$stun_server}
+
+#Configure the STUN server port, the default value is 3478.
+account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
+
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.5.nat.udp_update_enable = 1
+
+#Specify the keep-alive interval (in seconds), the default value is 30.
+account.5.nat.udp_update_time = 30
+
+#Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
+account.5.nat.rport = {$yealink_rport}
+
+
+#######################################################################################
+##                            Account5 Advance Settings                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.advanced.timer_t1 = 0.5
+##voice_mail.number.X =
+
+#Configure the session timer (in seconds), the default value of T1, T2, T3 is 0.5, 4, 5.
+account.5.advanced.timer_t1 = 0.5
+account.5.advanced.timer_t2 = 4
+account.5.advanced.timer_t4 = 5
+
+voice_mail.number.5 = *97
+
+
+#######################################################################################
+##                            Subscribe                                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.subscribe_mwi =
+
+account.5.subscribe_mwi = 1
+account.5.subscribe_mwi_expires = 3600
+
+#Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
+
+account.5.subscribe_acd_expires= 3600
+
+
+#######################################################################################
+##                            BLF List                                               ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.blf.blf_list_uri =
+
+#Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
+account.5.blf.blf_list_uri =
+
+account.5.blf_list_code =
+account.5.blf_list_barge_in_code =
+account.5.blf.subscribe_period = 1800
+
+account.5.blf.subscribe_event =
+account.5.out_dialog_blf_enable = 0
+
+
+#######################################################################################
+##                            BLA/SCA                                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.shared_line =
+
+#Assign account1 as shared line; 0-Disabled (default), 1-Broadsoft SCA, 2-BLA;
+{if isset($shared_line_5) }
+account.5.shared_line = {$shared_line_5}
+{else}
+account.5.shared_line = 0
+{/if}
+
+#Configure BLA number for account1 and the subscribe period (in seconds). It ranges from 60 to 7200, the default value is 300.
+account.5.bla_number =
+account.5.bla_subscribe_period = 300
+
+#######################################################################################
+##                            Audio Codec                                            ##
+#######################################################################################
+#Audio codecs for account1 (Y ranges from 1 to 11).
+#Enable or disable the specified codec; 0-Disabled, 1-Enabled;
+#account.5.codec.Y.enable =
+#The type of the specified codec.
+#account.5.codec.Y.payload_type =
+#The priority of the specified codec. It's available when the codec is enabled.
+#account.5.codec.Y.priority =
+#The payload of the specified codec.
+#account.5.codec.Y.rtpmap =
+
+account.5.codec.1.enable = 1
+account.5.codec.1.payload_type = PCMU
+account.5.codec.1.priority = 1
+account.5.codec.1.rtpmap = 0
+
+account.5.codec.2.enable = 1
+account.5.codec.2.payload_type = PCMA
+account.5.codec.2.priority = 2
+account.5.codec.2.rtpmap = 8
+
+account.5.codec.3.enable = 0
+account.5.codec.3.payload_type = G723_53
+account.5.codec.3.priority =0
+account.5.codec.3.rtpmap = 4
+
+account.5.codec.4.enable = 0
+account.5.codec.4.payload_type = G723_63
+account.5.codec.4.priority = 0
+account.5.codec.4.rtpmap = 4
+
+account.5.codec.5.enable = 1
+account.5.codec.5.payload_type = G729
+account.5.codec.5.priority = 3
+account.5.codec.5.rtpmap = 18
+
+account.5.codec.6.enable = 1
+account.5.codec.6.payload_type = G722
+account.5.codec.6.priority = 4
+account.5.codec.6.rtpmap = 9
+
+account.5.codec.7.enable = 0
+account.5.codec.7.payload_type = iLBC
+account.5.codec.7.priority =  0
+account.5.codec.7.rtpmap = 106
+
+account.5.codec.8.enable = 0
+account.5.codec.8.payload_type = G726-16
+account.5.codec.8.priority = 0
+account.5.codec.8.rtpmap = 103
+
+account.5.codec.9.enable = 0
+account.5.codec.9.payload_type = G726-24
+account.5.codec.9.priority = 0
+account.5.codec.9.rtpmap = 104
+
+account.5.codec.10.enable = 0
+account.5.codec.10.payload_type = G726-32
+account.5.codec.10.priority = 0
+account.5.codec.10.rtpmap = 102
+
+account.5.codec.11.enable = 0
+account.5.codec.11.payload_type = G726-40
+account.5.codec.11.priority = 0
+account.5.codec.11.rtpmap = 105
+
+account.5.codec.12.enable = 0
+account.5.codec.12.payload_type = GSM
+account.5.codec.12.priority = 0
+account.5.codec.12.rtpmap = 3
+
+
+#######################################################################################
+##                            Audio Advanced                                         ##
+#######################################################################################
+#Specify whether to encrypt the SIP messages; 0-Disabled (default), 1-Forced, 2-Negotiated;
+account.5.srtp_encryption =
+
+#Configure the RTP packet time. The valid values are 0 (Disabled), 10, 20 (default), 30, 40, 50, 60.
+account.5.ptime =
+
+
+#######################################################################################
+##                            Anonymous Call                                         ##
+#######################################################################################
+account.5.anonymous_call = 0
+account.5.anonymous_call_oncode =
+account.5.anonymous_call_offcode =
+
+account.5.reject_anonymous_call =
+account.5.anonymous_reject_oncode =
+account.5.anonymous_reject_offcode =
+
+#######################################################################################
+##                            Pickup Code                                            ##
+#######################################################################################
+account.5.dialoginfo_callpickup = 0
+
+#Configure the directed and group pickup codes for account 1, the settings on a per-account basis take precedence over the settings on the phone.
+account.5.group_pickup_code =
+account.5.direct_pickup_code =
+
+#######################################################################################
+##                            DTMF                                                   ##
+#######################################################################################
+#Configure the DTMF type; 0-INBAND, 1-RFC2833 (default), 2-SIP INFO, 3-AUTO+SIP INFO;
+account.5.dtmf.type =
+
+#Configure the DTMF info type when using the SIP INFO; 0-Disabled (default), 1-DTMF-Relay, 2-DTMF, 3-Telephone-Event;
+account.5.dtmf.info_type =
+
+#Configure the RFC2833 payload. It ranges from 96 to 255, the default value is 101.
+account.5.dtmf.dtmf_payload =
+
+#######################################################################################
+##                            Alert info                                             ##
+#######################################################################################
+#Enable or disable to use the Distinctive Ring Tones;  0-Disabled , 1-Enabled(default);
+account.5.alert_info_url_enable =
+
+#Assign a ringtone for account2. The system ring tones are: common (default), Ring1.wav - Ring8.wav.
+#If you set the custom ring tone (Busy.wav) for the phone, the value is: account.2.ringtone.ring_type = Config:Busy.wav
+#If you set the system ring tone (Ring2.wav) for the phone, the value is: account.2.ringtone.ring_type = Resource:Ring2.wav
+account.5.ringtone.ring_type =
+
+account.5.picture_info_enable = 1
+
+#######################################################################################
+##                            Conference                                             ##
+#######################################################################################
+#Configure the conference type; 0-Local (default), 2-Network Conference;
+account.5.conf_type =
+
+#Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
+account.5.conf_uri =
+
+#######################################################################################
+##                            cid source                                             ##
+#######################################################################################
+#Configure the type of SIP header(s) to carry the caller ID; 0-FROM (default), 1-PAI 2-PAI-FROM, 3-PRID-PAI-FROM, 4-PAI-RPID-FROM, 5-RPID-FROM;
+account.5.cid_source = {$yealink_cid_source}
+
+account.5.cid_source_privacy = 1
+account.5.cid_source_ppi = 1
+
+#Configure the presentation of the callee ID; 0-PAI-PRID, 1-DIALED DIGITS (default), 2-RFC4916;
+account.5.cp_source = 2
+
+#######################################################################################
+##                            Session Timer                                          ##
+#######################################################################################
+#Enable or disable the session timer, 0-Disabled (default), 1-Enabled;
+account.5.session_timer.enable = {$yealink_session_timer}
+
+#Configure the refresh session timer interval (in seconds). It ranges from 1 to 9999.
+account.5.session_timer.expires =
+
+#Configure the session timer refresher; 0-Uac (default), 1-Uas;
+account.5.session_timer.refresher =
+
+#######################################################################################
+##                            Music on Hold                                          ##
+#######################################################################################
+#Configure the type of Music on Hold; 0-Send the INVITE request to Music on Hold Server then hold the call; 1-Hold the call then send the INVITE request to Music on Hold Server;
+#Require reboot;
+account.5.music_on_hold_type =
+
+account.5.music_server_uri =
+
+#######################################################################################
+##                            Advanced                                               ##
+#######################################################################################
+#Enable or disable the auto answer feature; 0-Disabled (default), 1-Enabled;
+account.5.auto_answer =
+
+#Enable or disable the phone to record the missed call; 0-Disabled, 1-Enabled (default);
+account.5.missed_calllog =
+
+#Enable or disable the 100 reliable retransmission; 0-Disabled (default), 1-Enabled;
+account.5.100rel_enable = {$yealink_retransmission}
+
+#Enable or disable the "user=phone"; 0-Disabled (default), 1-Enabled;
+account.5.enable_user_equal_phone =
+
+#Enable or disable the simplified header field feature; 0-Disabled, 1-Enabled (default);
+account.5.compact_header_enable =
+
+#######################################################################################
+##                                   DND                                             ##
+#######################################################################################
+account.5.dnd.enable =
+account.5.dnd.on_code =
+account.5.dnd.off_code =
+
+#######################################################################################
+##                                 Call Forward                                      ##
+#######################################################################################
+#Enable or disable the busy forward feature for account; 0-Disabled (default), 1-Enabled;
+account.5.always_fwd.enable =
+account.5.always_fwd.target =
+account.5.always_fwd.off_code =
+account.5.always_fwd.on_code =
+
+account.5.busy_fwd.enable =
+account.5.busy_fwd.target =
+account.5.busy_fwd.off_code =
+account.5.busy_fwd.on_code =
+
+#Enable or disable the no answer forward feature for account1; 0-Disabled (default), 1-Enabled;
+#Configure the waiting ring times before forwarding. It ranges from 0 to 20, the default value is 2.
+account.5.timeout_fwd.enable =
+account.5.timeout_fwd.target =
+account.5.timeout_fwd.timeout =
+account.5.timeout_fwd.off_code =
+account.5.timeout_fwd.on_code =
+
+#######################################################################################
+##                                 Broadsoft Hoteling                                ##
+#######################################################################################
+account.5.hoteling.enable = 0
+account.5.hoteling.user_id = 0
+account.5.hoteling.password = 0
+account.5.hoteling.auto_login_enable = 0
+
+#######################################################################################
+##                                 Broadsoft ACD                                     ##
+#######################################################################################
+account.5.acd.enable = 0
+account.5.acd.unavailable_reason_enable = 0
+account.5.acd.available = 0
+account.5.acd.initial_state = 1
+
+#######################################################################################
+##                                 Broadsoft ACD Call Center                         ##
+#######################################################################################
+#Configure the ACD reason code of Broadsoft.(The valus of Y must be consecutive numbers.)
+#account.5.bw_acd_reason_code.Y = 500(lunch time)
+account.5.bw_acd_reason_code.1 =
+
+account.5.reason_code.1 =
+account.5.reason_code_name.1 = 0
+account.5.bw_disp_code.1 =
+account.5.bw_disp_code_name.1 =
+account.5.supervisor_info_code.1 =
+account.5.supervisor_info_code_name.1 =
+
+#######################################################################################
+##                                 Broadsoft Call Center                             ##
+#######################################################################################
+account.5.call_center.call_info_enable = 0
+account.5.call_center.show_call_info_time = 30
+account.5.call_center.disp_code_enable = 0
+account.5.call_center.trace_enable = 0
+account.5.call_center.emergency_enable = 0
+account.5.call_center.queue_status_enable = 0
+account.5.call_center.queue_status_light_enable = 0
+
+#######################################################################################
+##                                 Broadsoft XSI                                     ##
+#######################################################################################
+account.5.xsi.user =
+account.5.xsi.password =
+account.5.xsi.host =
+account.5.xsi.server_type =
+account.5.xsi.port =
+
+
+#######################################################################################
+##                                   NETWORK                                         ##
+#######################################################################################
+
+#######################################################################################
+##                           Account 6 Basic Settings                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.enable =
+{if isset($user_password_6) }
+account.6.enable = 1
+{else}
+account.6.enable = 0
+{/if}
+account.6.label = {$display_name_6}
+account.6.display_name = {$display_name_6}
+account.6.auth_name = {$auth_id_6}
+account.6.password = {$user_password_6}
+account.6.user_name = {$user_id_6}
+account.6.sip_server_host = {$server_address_6}
+account.6.sip_server_port = {$sip_port_6}
+account.6.outbound_host = {$outbound_proxy_6}
+
+account.6.outbound_port = {$sip_port_1}
+{if isset($yealink_sip_listen_port)}account.6.sip_listen_port = {$yealink_sip_listen_port}{else}account.6.sip_listen_port = 5060{/if}
+
+account.6.sip_listen_port = 5060
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS SRV;
+{if $sip_transport_6 == 'udp'}account.6.transport = 0{/if}
+{if $sip_transport_6 == 'tcp'}account.6.transport = 1{/if}
+{if $sip_transport_6 == 'tls'}account.6.transport = 2{/if}
+{if $sip_transport_6 == 'dns srv'}account.6.transport = 3{/if}
+
+account.6.outbound_proxy.1.address = {$outbound_proxy_primary_6}
+account.6.outbound_proxy.2.address = {$outbound_proxy_secondary_6}
+account.6.outbound_proxy_enable = {if isset($outbound_proxy_primary_6)}1{else}0{/if}
+
+#######################################################################################
+##                          Failback                                                 ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.reregister_enable = 0
+
+account.6.reregister_enable = 0
+account.6.retry_counts =
+account.6.failback_mode = 0
+account.6.failback_timeout = 3600
+account.6.naptr_build = 0
+account.6.fallback.redundancy_type = 0
+account.6.fallback.timeout = {$yealink_outbound_proxy_fallback_interval}
+account.6.sip_server.1.address =
+account.6.sip_server.1.port = 5060
+#Configure the register expiry time (in seconds), the default value is 3600.
+account.6.sip_server.1.expires = {$register_expires_6}
+account.6.sip_server.1.retry_counts = 3
+account.6.sip_server.1.failback_mode = 0
+account.6.sip_server.1.failback_timeout = 3600
+account.6.sip_server.1.register_on_enable = 0
+account.6.sip_server.2.address =
+account.6.sip_server.2.port = 5060
+account.6.sip_server.2.expires = 3600
+account.6.sip_server.2.retry_counts = 3
+account.6.sip_server.2.failback_mode = 0
+account.6.sip_server.2.failback_timeout = 3600
+account.6.sip_server.2.register_on_enable = 0
+account.6.dns_cache_type = 1
+
+account.6.dns_cache_a.1.name =
+account.6.dns_cache_a.1.ip =
+account.6.dns_cache_a.1.ttl = 300
+
+account.6.dns_cache_srv.1.name =
+account.6.dns_cache_srv.1.port = 0
+account.6.dns_cache_srv.1.priority = 0
+account.6.dns_cache_srv.1.target =
+account.6.dns_cache_srv.1.weight = 0
+account.6.dns_cache_srv.1.ttl = 300
+account.6.dns_cache_naptr.1.name =
+account.6.dns_cache_naptr.1.flags =
+account.6.dns_cache_naptr.1.order = 0
+account.6.dns_cache_naptr.1.preference = 0
+account.6.dns_cache_naptr.1.replace =
+account.6.dns_cache_naptr.1.service =
+account.6.dns_cache_naptr.1.ttl = 300
+
+account.6.static_cache_pri = 0
+
+#######################################################################################
+##                           Register Advanced                                       ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.sip_server_type =
+
+#Configure the SIP server type; 0-Default (default), 2-BroadSoft, 4-Cosmocom;
+account.6.sip_server_type =
+#Enable or disable the phone to send the account log-off message first and then send account register message when rebooting the phone; 0-Disabled (default), 1-Enabled;
+account.6.unregister_on_reboot =
+
+#Enable or disable the phone to only accept the message from the server; 0-Disabled (default), 1-Enabled;
+account.6.sip_trust_ctrl = 1
+
+#Configure the timeout (in seconds) for DNS query, the value ranges from 1 to 9, the default value is 8.
+account.6.dns_query_timeout=
+
+#Enable or disable the timer to periodically refresh the DNS-SRV query result; 0-Disabled (default), 1-Enabled;
+account.6.srv_ttl_timer_enable =
+account.6.proxy_require =
+
+
+#Enable or disable the phone to send the MAC address and line number in the Register message; 0-Disabled (default), 1-Enabled;
+account.6.register_mac =
+account.6.register_line =
+
+#Configure the interval (in seconds) the phone retries to register when account1 fails to register. It ranges from 0 to 1800, the default value is 30.
+account.6.reg_fail_retry_interval =
+
+#########################################################################
+##                     NAT Settings                                    ##
+#########################################################################
+## ranges from 1 to 6;
+##account.X.nat.nat_traversal = 0
+
+#Enable or disable the NAT traversal; 0-Disabled (default), 1-STUN;
+account.6.nat.nat_traversal = 0
+
+account.6.nat.stun_server =
+account.6.nat.stun_port = 3478
+
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.6.nat.udp_update_enable = 1
+
+#Specify the keep-alive interval (in seconds), the default value is 30.
+account.6.nat.udp_update_time = 30
+
+#Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
+account.6.nat.rport = {$yealink_rport}
+
+
+#######################################################################################
+##                            Account6 Advance Settings                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.advanced.timer_t1 = 0.5
+##voice_mail.number.X =
+
+#Configure the session timer (in seconds), the default value of T1, T2, T3 is 0.5, 4, 5.
+account.6.advanced.timer_t1 = 0.5
+account.6.advanced.timer_t2 = 4
+account.6.advanced.timer_t4 = 5
+
+voice_mail.number.6 = *97
+
+
+#######################################################################################
+##                            Subscribe                                              ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.subscribe_mwi =
+
+account.6.subscribe_mwi = 0
+account.6.subscribe_mwi_expires = 3600
+
+#Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
+
+account.6.subscribe_acd_expires= 3600
+
+
+#######################################################################################
+##                            BLF List                                               ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.blf.blf_list_uri =
+
+#Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
+account.6.blf.blf_list_uri =
+
+account.6.blf_list_code =
+account.6.blf_list_barge_in_code =
+account.6.blf.subscribe_period = 1800
+
+account.6.blf.subscribe_event =
+account.6.out_dialog_blf_enable = 0
+
+
+#######################################################################################
+##                            BLA/SCA                                                ##
+#######################################################################################
+## ranges from 1 to 6;
+##account.X.shared_line =
+
+#Assign account1 as shared line; 0-Disabled (default), 1-Broadsoft SCA, 2-BLA;
+{if isset($shared_line_6) }
+account.6.shared_line = {$shared_line_6}
+{else}
+account.6.shared_line = 0
+{/if}
+
+#Configure BLA number for account1 and the subscribe period (in seconds). It ranges from 60 to 7200, the default value is 300.
+account.6.bla_number =
+account.6.bla_subscribe_period = 300
+
+#######################################################################################
+##                            Audio Codec                                            ##
+#######################################################################################
+#Audio codecs for account1 (Y ranges from 1 to 11).
+#Enable or disable the specified codec; 0-Disabled, 1-Enabled;
+#account.6.codec.Y.enable =
+#The type of the specified codec.
+#account.6.codec.Y.payload_type =
+#The priority of the specified codec. It's available when the codec is enabled.
+#account.6.codec.Y.priority =
+#The payload of the specified codec.
+#account.6.codec.Y.rtpmap =
+
+account.6.codec.1.enable = 1
+account.6.codec.1.payload_type = PCMU
+account.6.codec.1.priority = 1
+account.6.codec.1.rtpmap = 0
+
+account.6.codec.2.enable = 1
+account.6.codec.2.payload_type = PCMA
+account.6.codec.2.priority = 2
+account.6.codec.2.rtpmap = 8
+
+account.6.codec.3.enable = 0
+account.6.codec.3.payload_type = G723_53
+account.6.codec.3.priority =0
+account.6.codec.3.rtpmap = 4
+
+account.6.codec.4.enable = 0
+account.6.codec.4.payload_type = G723_63
+account.6.codec.4.priority = 0
+account.6.codec.4.rtpmap = 4
+
+account.6.codec.5.enable = 1
+account.6.codec.5.payload_type = G729
+account.6.codec.5.priority = 3
+account.6.codec.5.rtpmap = 18
+
+account.6.codec.6.enable = 1
+account.6.codec.6.payload_type = G722
+account.6.codec.6.priority = 4
+account.6.codec.6.rtpmap = 9
+
+account.6.codec.7.enable = 0
+account.6.codec.7.payload_type = iLBC
+account.6.codec.7.priority =  0
+account.6.codec.7.rtpmap = 106
+
+account.6.codec.8.enable = 0
+account.6.codec.8.payload_type = G726-16
+account.6.codec.8.priority = 0
+account.6.codec.8.rtpmap = 103
+
+account.6.codec.9.enable = 0
+account.6.codec.9.payload_type = G726-24
+account.6.codec.9.priority = 0
+account.6.codec.9.rtpmap = 104
+
+account.6.codec.10.enable = 0
+account.6.codec.10.payload_type = G726-32
+account.6.codec.10.priority = 0
+account.6.codec.10.rtpmap = 102
+
+account.6.codec.11.enable = 0
+account.6.codec.11.payload_type = G726-40
+account.6.codec.11.priority = 0
+account.6.codec.11.rtpmap = 105
+
+account.6.codec.12.enable = 0
+account.6.codec.12.payload_type = GSM
+account.6.codec.12.priority = 0
+account.6.codec.12.rtpmap = 3
+
+
+#######################################################################################
+##                            Audio Advanced                                         ##
+#######################################################################################
+#Specify whether to encrypt the SIP messages; 0-Disabled (default), 1-Forced, 2-Negotiated;
+account.6.srtp_encryption =
+
+#Configure the RTP packet time. The valid values are 0 (Disabled), 10, 20 (default), 30, 40, 50, 60.
+account.6.ptime =
+
+
+#######################################################################################
+##                            Anonymous Call                                         ##
+#######################################################################################
+account.6.anonymous_call = 0
+account.6.anonymous_call_oncode =
+account.6.anonymous_call_offcode =
+
+account.6.reject_anonymous_call =
+account.6.anonymous_reject_oncode =
+account.6.anonymous_reject_offcode =
+
+#######################################################################################
+##                            Pickup Code                                            ##
+#######################################################################################
+account.5.dialoginfo_callpickup = 0
+
+#Configure the directed and group pickup codes for account 1, the settings on a per-account basis take precedence over the settings on the phone.
+account.6.group_pickup_code =
+account.56.direct_pickup_code =
+
+#######################################################################################
+##                            DTMF                                                   ##
+#######################################################################################
+#Configure the DTMF type; 0-INBAND, 1-RFC2833 (default), 2-SIP INFO, 3-AUTO+SIP INFO;
+account.6.dtmf.type =
+
+#Configure the DTMF info type when using the SIP INFO; 0-Disabled (default), 1-DTMF-Relay, 2-DTMF, 3-Telephone-Event;
+account.6.dtmf.info_type =
+
+#Configure the RFC2833 payload. It ranges from 96 to 255, the default value is 101.
+account.6.dtmf.dtmf_payload =
+
+#######################################################################################
+##                            Alert info                                             ##
+#######################################################################################
+#Enable or disable to use the Distinctive Ring Tones;  0-Disabled , 1-Enabled(default);
+account.6.alert_info_url_enable =
+
+#Assign a ringtone for account2. The system ring tones are: common (default), Ring1.wav - Ring8.wav.
+#If you set the custom ring tone (Busy.wav) for the phone, the value is: account.2.ringtone.ring_type = Config:Busy.wav
+#If you set the system ring tone (Ring2.wav) for the phone, the value is: account.2.ringtone.ring_type = Resource:Ring2.wav
+account.6.ringtone.ring_type =
+
+account.6.picture_info_enable = 1
+
+#######################################################################################
+##                            Conference                                             ##
+#######################################################################################
+#Configure the conference type; 0-Local (default), 2-Network Conference;
+account.6.conf_type =
+
+#Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
+account.6.conf_uri =
+
+#######################################################################################
+##                            cid source                                             ##
+#######################################################################################
+#Configure the type of SIP header(s) to carry the caller ID; 0-FROM (default), 1-PAI 2-PAI-FROM, 3-PRID-PAI-FROM, 4-PAI-RPID-FROM, 5-RPID-FROM;
+account.6.cid_source = {$yealink_cid_source}
+
+account.6.cid_source_privacy = 1
+account.6.cid_source_ppi = 1
+
+#Configure the presentation of the callee ID; 0-PAI-PRID, 1-DIALED DIGITS (default), 2-RFC4916;
+account.6.cp_source = 2
+
+#######################################################################################
+##                            Session Timer                                          ##
+#######################################################################################
+#Enable or disable the session timer, 0-Disabled (default), 1-Enabled;
+account.6.session_timer.enable = {$yealink_session_timer}
+
+#Configure the refresh session timer interval (in seconds). It ranges from 1 to 9999.
+account.6.session_timer.expires =
+
+#Configure the session timer refresher; 0-Uac (default), 1-Uas;
+account.6.session_timer.refresher =
+
+#######################################################################################
+##                            Music on Hold                                          ##
+#######################################################################################
+#Configure the type of Music on Hold; 0-Send the INVITE request to Music on Hold Server then hold the call; 1-Hold the call then send the INVITE request to Music on Hold Server;
+#Require reboot;
+account.6.music_on_hold_type =
+
+account.6.music_server_uri =
+
+#######################################################################################
+##                            Advanced                                               ##
+#######################################################################################
+#Enable or disable the auto answer feature; 0-Disabled (default), 1-Enabled;
+account.6.auto_answer =
+
+#Enable or disable the phone to record the missed call; 0-Disabled, 1-Enabled (default);
+account.6.missed_calllog =
+
+#Enable or disable the 100 reliable retransmission; 0-Disabled (default), 1-Enabled;
+account.6.100rel_enable = {$yealink_retransmission}
+
+#Enable or disable the "user=phone"; 0-Disabled (default), 1-Enabled;
+account.6.enable_user_equal_phone =
+
+#Enable or disable the simplified header field feature; 0-Disabled, 1-Enabled (default);
+account.6.compact_header_enable =
+
+#######################################################################################
+##                                   DND                                             ##
+#######################################################################################
+account.6.dnd.enable =
+account.6.dnd.on_code =
+account.6.dnd.off_code =
+
+#######################################################################################
+##                                 Call Forward                                      ##
+#######################################################################################
+#Enable or disable the busy forward feature for account; 0-Disabled (default), 1-Enabled;
+account.6.always_fwd.enable =
+account.6.always_fwd.target =
+account.6.always_fwd.off_code =
+account.6.always_fwd.on_code =
+
+account.6.busy_fwd.enable =
+account.6.busy_fwd.target =
+account.6.busy_fwd.off_code =
+account.6.busy_fwd.on_code =
+
+#Enable or disable the no answer forward feature for account1; 0-Disabled (default), 1-Enabled;
+#Configure the waiting ring times before forwarding. It ranges from 0 to 20, the default value is 2.
+account.6.timeout_fwd.enable =
+account.6.timeout_fwd.target =
+account.6.timeout_fwd.timeout =
+account.6.timeout_fwd.off_code =
+account.6.timeout_fwd.on_code =
+
+#######################################################################################
+##                                 Broadsoft Hoteling                                ##
+#######################################################################################
+account.6.hoteling.enable = 0
+account.6.hoteling.user_id = 0
+account.6.hoteling.password = 0
+account.6.hoteling.auto_login_enable = 0
+
+#######################################################################################
+##                                 Broadsoft ACD                                     ##
+#######################################################################################
+account.6.acd.enable = 0
+account.6.acd.unavailable_reason_enable = 0
+account.6.acd.available = 0
+account.6.acd.initial_state = 1
+
+#######################################################################################
+##                                 Broadsoft ACD Call Center                         ##
+#######################################################################################
+#Configure the ACD reason code of Broadsoft.(The valus of Y must be consecutive numbers.)
+#account.6.bw_acd_reason_code.Y = 500(lunch time)
+account.6.bw_acd_reason_code.1 =
+
+account.6.reason_code.1 =
+account.6.reason_code_name.1 = 0
+account.6.bw_disp_code.1 =
+account.6.bw_disp_code_name.1 =
+account.6.supervisor_info_code.1 =
+account.6.supervisor_info_code_name.1 =
+
+#######################################################################################
+##                                 Broadsoft Call Center                             ##
+#######################################################################################
+account.6.call_center.call_info_enable = 0
+account.6.call_center.show_call_info_time = 30
+account.6.call_center.disp_code_enable = 0
+account.6.call_center.trace_enable = 0
+account.6.call_center.emergency_enable = 0
+account.6.call_center.queue_status_enable = 0
+account.6.call_center.queue_status_light_enable = 0
+
+#######################################################################################
+##                                 Broadsoft XSI                                     ##
+#######################################################################################
+account.6.xsi.user =
+account.6.xsi.password =
+account.6.xsi.host =
+account.6.xsi.server_type =
+account.6.xsi.port =
+
+
+#######################################################################################
+##                                   NETWORK                                         ##
+#######################################################################################
+
+#######################################################################################
+##                             Line Key                                              ##
+#######################################################################################
+
+#The x of the parameter "linekey.x.line" ranges from 1 to 6.
+#The default value equals to the value of x. For example, the default value of the parameter "linekey.1.line" is 1.
+#linekey.x.lable--Define the label for each line key. Meet-Me Conference "1" or BLF "16" require pick_value.
+
+{foreach $keys['line'] as $row}
 #Configure Line Key {$row.device_key_id}
 linekey.{$row.device_key_id}.line = {$row.device_key_line}
 linekey.{$row.device_key_id}.value = {$row.device_key_value}
+{if $row.device_key_type == "1" || $row.device_key_type == "16"}
 linekey.{$row.device_key_id}.pickup_value = {$row.device_key_extension}
+{else}
 linekey.{$row.device_key_id}.extension = {$row.device_key_extension}
+{/if}
 linekey.{$row.device_key_id}.type = {$row.device_key_type}
 linekey.{$row.device_key_id}.xml_phonebook =
 linekey.{$row.device_key_id}.label = {$row.device_key_label}
 
+{/foreach}
+
+
+#######################################################################################
+##                             Memory Key (For T38G only)                            ##
+#######################################################################################
+#X ranges from 1 to 10;
+#memorykey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
+#The value 0 of the "memorykey.x.line" stands for Auto, it means the first available line.
+#But, when the DSS key is configured as BLF, BLF List, Shared Line, Call Park, Pick Up, ACD or Voice Mail feature, the value 0 stands for line 1.
+#memorykey.x.value--Enter the value of some features. E.g. When configuring the DSS key to be BLF, enter the number of the monitored user.
+#memorykey.x.extension--Enter the pickup code, this parameter is only appilicable to BLF.
+#memorykey.x.type--Assign the desired feature to the memory key.
+#Valid types are:  0-N/A(default for memory key)  1-Conference     2-Forward    3-Transfer      4-Hold        5-DND             6-Redial                        7-Call Return     8-SMS
+#                  9-Call Pickup                  10-Call Park     11-DTMF      12-Voicemail    13-SpeedDial  14-Intercom       15-Line(default for line key)   16-BLF            17-URL
+#                  18-Group Listening             19-Public Hold   20-Private   21-Shared Line  22-XML Group  23-Group Pickup   24-Paging                       25-Record         27-XML Browser
+#                  34-Hot Desking                 35-URL Record    38-LDAP      39-BLF List     40-Prefix     41-Zero-Sp-Touch  42-ACD                          45-Local Group    46-Broadsoft Group
+#memorykey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the DSS key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
+#memorykey.x.sub_type =
+
+{foreach $keys["memory"] as $row}
 #Expansion Memory Key {$row.device_key_id}
 memorykey.{$row.device_key_id}.type = {$row.device_key_type}
 memorykey.{$row.device_key_id}.line = {$row.device_key_line}
@@ -496,25 +2903,113 @@ memorykey.{$row.device_key_id}.label = {$row.device_key_label}
 memorykey.{$row.device_key_id}.xml_phonebook =
 memorykey.{$row.device_key_id}.sub_type =
 
+{/foreach}
+
+
+##########################################################################################
+##                         Programmable Key (For T38G only)                             ##
+##########################################################################################
+#X ranges from 1 to 15.
+#programablekey.x.type--Customize the programmable key type.
+#The valid types are:
+#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
+#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
+#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
+#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
+#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
+#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
+
+{foreach $keys["programmable"] as $row}
 programablekey.{$row.device_key_id}.type = {$row.device_key_type}
 programablekey.{$row.device_key_id}.line = {$row.device_key_line}
 programablekey.{$row.device_key_id}.value = {$row.device_key_value}
 programablekey.{$row.device_key_id}.xml_phonebook =
 programablekey.{$row.device_key_id}.history_type =
 programablekey.{$row.device_key_id}.label = {$row.device_key_label}
+
+{/foreach}
+
+#programablekey.x.value =
+#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
+#programablekey.x.history_type =
+
+#programablekey.x.label--This parameter is only available to the key 1 to key 4.
+
+#History
+#programablekey.1.type = 28
+#programablekey.1.line = 1
+#programablekey.1.value = 
+#programablekey.1.xml_phonebook =
+#programablekey.1.history_type =
+#programablekey.1.label =
+
+#Directory
+#programablekey.2.type = 29
+#programablekey.2.line = 1
+#programablekey.2.value =
+#programablekey.2.xml_phonebook =
+#programablekey.2.history_type =
+#programablekey.2.label =
+
+#DND
+programablekey.3.type = 5
+programablekey.3.line = 1
+programablekey.3.value =
+programablekey.3.xml_phonebook =
+programablekey.3.history_type =
+programablekey.3.label =
+
+#Menu
+#programablekey.4.type = 30
+#programablekey.4.line =
+#programablekey.4.value =
+#programablekey.4.xml_phonebook =
+#programablekey.4.history_type =
+#programablekey.4.label =
+
+##########################################################################################
+##                                  Expansion Module 1                                  ##
+##########################################################################################
+#X ranges from 1 to 16, Y ranges from 1 to 40.
+#expansion_module.x.key.y.type = 37 (Switch by default)
+#expansion_module.x.key.y.line = 0
+#expansion_module.x.key.y.value =
+#expansion_module.x.key.y.extension =
+#expansion_module.x.key.y.label =
+#expansion_module.X.key.Y.xml_phonebook =
+
 {$rownum = 1}
 
+{foreach $keys["expansion"] as $row}
+{if $rownum <= 40}
 expansion_module.1.key.{$row.device_key_id}.type = {$row.device_key_type}
 expansion_module.1.key.{$row.device_key_id}.line = {$row.device_key_line}
 expansion_module.1.key.{$row.device_key_id}.value = {$row.device_key_value}
 expansion_module.1.key.{$row.device_key_id}.extension = {$row.device_key_extension}
 expansion_module.1.key.{$row.device_key_id}.label = {$row.device_key_label}
 expansion_module.1.key.{$row.device_key_id}.xml_phonebook =
-
+{else}
 expansion_module.2.key.{$row.device_key_id - 40}.type = {$row.device_key_type}
 expansion_module.2.key.{$row.device_key_id - 40}.line = {$row.device_key_line}
 expansion_module.2.key.{$row.device_key_id - 40}.value = {$row.device_key_value}
 expansion_module.2.key.{$row.device_key_id - 40}.extension = {$row.device_key_extension}
 expansion_module.2.key.{$row.device_key_id - 40}.label = {$row.device_key_label}
 expansion_module.2.key.{$row.device_key_id - 40}.xml_phonebook =
+{/if}
 {$rownum = $rownum + 1}
+
+{/foreach}
+
+##########################################################################################
+##                                  Expansion Module 2                                  ##
+##########################################################################################
+
+#Expansion module 2 key 1
+#expansion_module.2.key.1.type =
+#expansion_module.2.key.1.line =
+#expansion_module.2.key.1.value =
+#expansion_module.2.key.1.extension =
+#expansion_module.2.key.1.label =
+#expansion_module.2.key.1.xml_phonebook =
+#expansion_module.2.key.1.type =
+#expansion_module.2.key.1.label =

--- a/resources/templates/provision/yealink/t48g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t48g/{$mac}.cfg
@@ -175,7 +175,7 @@ account.1.subscribe_mwi = 1
 account.1.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm = 1
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.1.subscribe_acd_expires= 3600
 
@@ -640,7 +640,7 @@ account.2.subscribe_mwi = 1
 account.2.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm = 1
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.2.subscribe_acd_expires= 3600
 
@@ -1149,7 +1149,7 @@ account.3.subscribe_mwi = 1
 account.3.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm = 1
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.3.subscribe_acd_expires= 3600
 
@@ -1640,7 +1640,7 @@ account.4.subscribe_mwi = 1
 account.4.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm = 1
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.4.subscribe_acd_expires= 3600
 
@@ -2131,7 +2131,7 @@ account.5.subscribe_mwi = 1
 account.5.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm = 1
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.5.subscribe_acd_expires= 3600
 
@@ -2621,7 +2621,7 @@ account.6.subscribe_mwi = 0
 account.6.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.6.subscribe_acd_expires= 3600
 

--- a/resources/templates/provision/yealink/t48s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t48s/{$mac}.cfg
@@ -175,7 +175,7 @@ account.1.subscribe_mwi = 1
 account.1.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm = 1
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.1.subscribe_acd_expires= 3600
 
@@ -640,7 +640,7 @@ account.2.subscribe_mwi = 1
 account.2.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm = 1
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.2.subscribe_acd_expires= 3600
 
@@ -1149,7 +1149,7 @@ account.3.subscribe_mwi = 1
 account.3.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm = 1
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.3.subscribe_acd_expires= 3600
 
@@ -1640,7 +1640,7 @@ account.4.subscribe_mwi = 1
 account.4.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm = 1
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.4.subscribe_acd_expires= 3600
 
@@ -2131,7 +2131,7 @@ account.5.subscribe_mwi = 1
 account.5.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm = 1
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.5.subscribe_acd_expires= 3600
 
@@ -2621,7 +2621,7 @@ account.6.subscribe_mwi = 0
 account.6.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.6.subscribe_acd_expires= 3600
 

--- a/resources/templates/provision/yealink/t49g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t49g/{$mac}.cfg
@@ -175,7 +175,7 @@ account.1.subscribe_mwi = 1
 account.1.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi_to_vm = 1
+account.1.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.1.subscribe_acd_expires= 3600
 
@@ -640,7 +640,7 @@ account.2.subscribe_mwi = 1
 account.2.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.2.subscribe_mwi_to_vm = 1
+account.2.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.2.subscribe_acd_expires= 3600
 
@@ -1149,7 +1149,7 @@ account.3.subscribe_mwi = 1
 account.3.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.3.subscribe_mwi_to_vm = 1
+account.3.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.3.subscribe_acd_expires= 3600
 
@@ -1640,7 +1640,7 @@ account.4.subscribe_mwi = 1
 account.4.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.4.subscribe_mwi_to_vm = 1
+account.4.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.4.subscribe_acd_expires= 3600
 
@@ -2131,7 +2131,7 @@ account.5.subscribe_mwi = 1
 account.5.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.5.subscribe_mwi_to_vm = 1
+account.5.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.5.subscribe_acd_expires= 3600
 
@@ -2621,7 +2621,7 @@ account.6.subscribe_mwi = 0
 account.6.subscribe_mwi_expires = 3600
 
 #Enable or disable the phone to subscribe to the voicemail through the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.6.subscribe_mwi_to_vm = 0
+account.6.subscribe_mwi_to_vm = {$yealink_subscribe_mwi_to_vm}
 
 account.6.subscribe_acd_expires= 3600
 


### PR DESCRIPTION
Adds new variable in Yealink provisioning templates to allow control of MWI subscribe setting behavior on all accounts. Setting the new variable once affects all accounts.

New variable:
yealink_subscribe_mwi_to_vm.

Setting affected:
account.X.subscribe_mwi_to_vm setting

Phones affected:
T1x
T2x
T3x
T4x

May affect MWI subscription behavior. Yealink default is 0, many of the old templates hard coded 1. This change may affect MWI behavior for some users, so check to make sure the variable is added in FusionPBX to match your previous settings before upgrading.