### PR TITLE
Add Yealink alert_info Distinctive Ring Variables

### DIFF
--- a/resources/templates/provision/yealink/t19p/y000000000053.cfg
+++ b/resources/templates/provision/yealink/t19p/y000000000053.cfg
@@ -781,11 +781,29 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##         	               Auto Redial                                               ##

--- a/resources/templates/provision/yealink/t20p/y000000000007.cfg
+++ b/resources/templates/provision/yealink/t20p/y000000000007.cfg
@@ -781,11 +781,29 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##         	               Auto Redial                                               ##

--- a/resources/templates/provision/yealink/t21p/y000000000052.cfg
+++ b/resources/templates/provision/yealink/t21p/y000000000052.cfg
@@ -1367,12 +1367,30 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #1-Ring1.wav, 2-Ring2.wav, 3-Ring3.wav, 4-Ring4.wav, 5-Ring5.wav, 6-Ring6.wav, 7-Ring7.wav, 8-Ring8.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   Call Waiting                                    ##

--- a/resources/templates/provision/yealink/t22p/y000000000005.cfg
+++ b/resources/templates/provision/yealink/t22p/y000000000005.cfg
@@ -781,11 +781,29 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##         	               Auto Redial                                               ##

--- a/resources/templates/provision/yealink/t23g/y000000000044.cfg
+++ b/resources/templates/provision/yealink/t23g/y000000000044.cfg
@@ -1367,12 +1367,30 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #1-Ring1.wav, 2-Ring2.wav, 3-Ring3.wav, 4-Ring4.wav, 5-Ring5.wav, 6-Ring6.wav, 7-Ring7.wav, 8-Ring8.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   Call Waiting                                    ##

--- a/resources/templates/provision/yealink/t23p/y000000000044.cfg
+++ b/resources/templates/provision/yealink/t23p/y000000000044.cfg
@@ -1367,12 +1367,30 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #1-Ring1.wav, 2-Ring2.wav, 3-Ring3.wav, 4-Ring4.wav, 5-Ring5.wav, 6-Ring6.wav, 7-Ring7.wav, 8-Ring8.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   Call Waiting                                    ##

--- a/resources/templates/provision/yealink/t26p/y000000000004.cfg
+++ b/resources/templates/provision/yealink/t26p/y000000000004.cfg
@@ -781,11 +781,29 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##         	               Auto Redial                                               ##

--- a/resources/templates/provision/yealink/t27g/y000000000069.cfg
+++ b/resources/templates/provision/yealink/t27g/y000000000069.cfg
@@ -1367,12 +1367,30 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #1-Ring1.wav, 2-Ring2.wav, 3-Ring3.wav, 4-Ring4.wav, 5-Ring5.wav, 6-Ring6.wav, 7-Ring7.wav, 8-Ring8.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   Call Waiting                                    ##

--- a/resources/templates/provision/yealink/t27p/y000000000045.cfg
+++ b/resources/templates/provision/yealink/t27p/y000000000045.cfg
@@ -1367,12 +1367,30 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #1-Ring1.wav, 2-Ring2.wav, 3-Ring3.wav, 4-Ring4.wav, 5-Ring5.wav, 6-Ring6.wav, 7-Ring7.wav, 8-Ring8.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   Call Waiting                                    ##

--- a/resources/templates/provision/yealink/t28p/y000000000000.cfg
+++ b/resources/templates/provision/yealink/t28p/y000000000000.cfg
@@ -781,11 +781,29 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##         	               Auto Redial                                               ##

--- a/resources/templates/provision/yealink/t29g/y000000000046.cfg
+++ b/resources/templates/provision/yealink/t29g/y000000000046.cfg
@@ -1367,12 +1367,30 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #1-Ring1.wav, 2-Ring2.wav, 3-Ring3.wav, 4-Ring4.wav, 5-Ring5.wav, 6-Ring6.wav, 7-Ring7.wav, 8-Ring8.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   Call Waiting                                    ##

--- a/resources/templates/provision/yealink/t32g/y000000000032.cfg
+++ b/resources/templates/provision/yealink/t32g/y000000000032.cfg
@@ -781,11 +781,29 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##         	               Auto Redial                                               ##

--- a/resources/templates/provision/yealink/t38g/y000000000038.cfg
+++ b/resources/templates/provision/yealink/t38g/y000000000038.cfg
@@ -781,11 +781,29 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##         	               Auto Redial                                               ##

--- a/resources/templates/provision/yealink/t40p/y000000000054.cfg
+++ b/resources/templates/provision/yealink/t40p/y000000000054.cfg
@@ -1358,12 +1358,30 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #1-Ring1.wav, 2-Ring2.wav, 3-Ring3.wav, 4-Ring4.wav, 5-Ring5.wav, 6-Ring6.wav, 7-Ring7.wav, 8-Ring8.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   Call Waiting                                    ##

--- a/resources/templates/provision/yealink/t41p/y000000000036.cfg
+++ b/resources/templates/provision/yealink/t41p/y000000000036.cfg
@@ -1367,12 +1367,30 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #1-Ring1.wav, 2-Ring2.wav, 3-Ring3.wav, 4-Ring4.wav, 5-Ring5.wav, 6-Ring6.wav, 7-Ring7.wav, 8-Ring8.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   Call Waiting                                    ##

--- a/resources/templates/provision/yealink/t41s/y000000000068.cfg
+++ b/resources/templates/provision/yealink/t41s/y000000000068.cfg
@@ -1367,12 +1367,30 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #1-Ring1.wav, 2-Ring2.wav, 3-Ring3.wav, 4-Ring4.wav, 5-Ring5.wav, 6-Ring6.wav, 7-Ring7.wav, 8-Ring8.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   Call Waiting                                    ##

--- a/resources/templates/provision/yealink/t42g/y000000000029.cfg
+++ b/resources/templates/provision/yealink/t42g/y000000000029.cfg
@@ -1385,12 +1385,30 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #1-Ring1.wav, 2-Ring2.wav, 3-Ring3.wav, 4-Ring4.wav, 5-Ring5.wav, 6-Ring6.wav, 7-Ring7.wav, 8-Ring8.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   Call Waiting                                    ##

--- a/resources/templates/provision/yealink/t42s/y000000000067.cfg
+++ b/resources/templates/provision/yealink/t42s/y000000000067.cfg
@@ -1352,8 +1352,27 @@ dialplan.area_code.code=
 #######################################################################################
 ##                                 Rings Settings                                    ##
 #######################################################################################
-distinctive_ring_tones.alert_info.1.ringer=
-distinctive_ring_tones.alert_info.1.text=
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
+
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   IME Settings                                    ##

--- a/resources/templates/provision/yealink/t46g/y000000000028.cfg
+++ b/resources/templates/provision/yealink/t46g/y000000000028.cfg
@@ -1372,12 +1372,30 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #1-Ring1.wav, 2-Ring2.wav, 3-Ring3.wav, 4-Ring4.wav, 5-Ring5.wav, 6-Ring6.wav, 7-Ring7.wav, 8-Ring8.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   Call Waiting                                    ##

--- a/resources/templates/provision/yealink/t46s/y000000000066.cfg
+++ b/resources/templates/provision/yealink/t46s/y000000000066.cfg
@@ -1352,8 +1352,27 @@ dialplan.area_code.code=
 #######################################################################################
 ##                                 Rings Settings                                    ##
 #######################################################################################
-distinctive_ring_tones.alert_info.1.ringer=
-distinctive_ring_tones.alert_info.1.text=
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
+
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   IME Settings                                    ##
@@ -1675,4 +1694,3 @@ directory_setting.gb_pab_directory.enable =
 directory_setting.gb_pab_directory.priority =
 search_in_dialing.gb_pab_directory.priority =
 search_in_dialing.gb_pab_directory.enable =
-

--- a/resources/templates/provision/yealink/t48g/y000000000035.cfg
+++ b/resources/templates/provision/yealink/t48g/y000000000035.cfg
@@ -1384,12 +1384,30 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #1-Ring1.wav, 2-Ring2.wav, 3-Ring3.wav, 4-Ring4.wav, 5-Ring5.wav, 6-Ring6.wav, 7-Ring7.wav, 8-Ring8.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   Call Waiting                                    ##

--- a/resources/templates/provision/yealink/t48s/y000000000065.cfg
+++ b/resources/templates/provision/yealink/t48s/y000000000065.cfg
@@ -1352,8 +1352,27 @@ dialplan.area_code.code=
 #######################################################################################
 ##                                 Rings Settings                                    ##
 #######################################################################################
-distinctive_ring_tones.alert_info.1.ringer=
-distinctive_ring_tones.alert_info.1.text=
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
+
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   IME Settings                                    ##

--- a/resources/templates/provision/yealink/t49g/y000000000051.cfg
+++ b/resources/templates/provision/yealink/t49g/y000000000051.cfg
@@ -1367,12 +1367,30 @@ hotdesking.dsskey_outbound_enable =
 #"X" ranges from 1 to 10;
 #Configure the text to map the keywords contained in the "Alert-info" header.
 #distinctive_ring_tones.alert_info.X.text = family
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 #Specify the ring tone for each text. It ranges from 1 to 8. The default value 1 stands for Ring1.wav.
 #1-Ring1.wav, 2-Ring2.wav, 3-Ring3.wav, 4-Ring4.wav, 5-Ring5.wav, 6-Ring6.wav, 7-Ring7.wav, 8-Ring8.wav.
 #distinctive_ring_tones.alert_info.X.ringer = 1
-distinctive_ring_tones.alert_info.1.ringer =
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   Call Waiting                                    ##

--- a/resources/templates/provision/yealink/t52s/y000000000074.cfg
+++ b/resources/templates/provision/yealink/t52s/y000000000074.cfg
@@ -1348,8 +1348,27 @@ dialplan.area_code.code=
 #######################################################################################
 ##                                 Rings Settings                                    ##
 #######################################################################################
-distinctive_ring_tones.alert_info.1.ringer=
-distinctive_ring_tones.alert_info.1.text=
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
+
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   IME Settings                                    ##

--- a/resources/templates/provision/yealink/t54s/y000000000070.cfg
+++ b/resources/templates/provision/yealink/t54s/y000000000070.cfg
@@ -1347,8 +1347,27 @@ dialplan.area_code.code=
 #######################################################################################
 ##                                 Rings Settings                                    ##
 #######################################################################################
-distinctive_ring_tones.alert_info.1.ringer=
-distinctive_ring_tones.alert_info.1.text=
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
+
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10}
 
 #######################################################################################
 ##                                   IME Settings                                    ##

--- a/resources/templates/provision/yealink/t56a/y000000000056.cfg
+++ b/resources/templates/provision/yealink/t56a/y000000000056.cfg
@@ -1245,15 +1245,33 @@ hotdesking.dsskey_outbound_enable =
 ###distinctive_ring_tones.alert_info.x.ringer = 
 
 ###It configures the internal ringer text for distinctive ringtone.
-###Example: distinctive_ring_tones.alert_info.1.text = Family
+###Example: distinctive_ring_tones.alert_info.1.text = family
 ###The default value is blank.
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 ###It configures the desired ring tones for each text.
 ###The value ranges from 1 to 8, the digit stands for the appropriate ringtone.
 ###Ring tones 6-8 are only applicable to SIP-T46G IP phones.
 ###The default value is 1.
-distinctive_ring_tones.alert_info.1.ringer = 
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10} 
 
 #######################################################################################
 ##                                   Call Waiting                                    ##       

--- a/resources/templates/provision/yealink/t58v/y000000000058.cfg
+++ b/resources/templates/provision/yealink/t58v/y000000000058.cfg
@@ -1245,15 +1245,33 @@ hotdesking.dsskey_outbound_enable =
 ###distinctive_ring_tones.alert_info.x.ringer = 
 
 ###It configures the internal ringer text for distinctive ringtone.
-###Example: distinctive_ring_tones.alert_info.1.text = Family
+###Example: distinctive_ring_tones.alert_info.1.text =  Family
 ###The default value is blank.
-distinctive_ring_tones.alert_info.1.text =
+distinctive_ring_tones.alert_info.1.text = {$yealink_ring_text_1}
+distinctive_ring_tones.alert_info.2.text = {$yealink_ring_text_2}
+distinctive_ring_tones.alert_info.3.text = {$yealink_ring_text_3}
+distinctive_ring_tones.alert_info.4.text = {$yealink_ring_text_4}
+distinctive_ring_tones.alert_info.5.text = {$yealink_ring_text_5}
+distinctive_ring_tones.alert_info.6.text = {$yealink_ring_text_6}
+distinctive_ring_tones.alert_info.7.text = {$yealink_ring_text_7}
+distinctive_ring_tones.alert_info.8.text = {$yealink_ring_text_8}
+distinctive_ring_tones.alert_info.9.text = {$yealink_ring_text_9}
+distinctive_ring_tones.alert_info.10.text = {$yealink_ring_text_10}
 
 ###It configures the desired ring tones for each text.
 ###The value ranges from 1 to 8, the digit stands for the appropriate ringtone.
 ###Ring tones 6-8 are only applicable to SIP-T46G IP phones.
 ###The default value is 1.
-distinctive_ring_tones.alert_info.1.ringer = 
+distinctive_ring_tones.alert_info.1.ringer = {$yealink_ring_file_1}
+distinctive_ring_tones.alert_info.2.ringer = {$yealink_ring_file_2}
+distinctive_ring_tones.alert_info.3.ringer = {$yealink_ring_file_3}
+distinctive_ring_tones.alert_info.4.ringer = {$yealink_ring_file_4}
+distinctive_ring_tones.alert_info.5.ringer = {$yealink_ring_file_5}
+distinctive_ring_tones.alert_info.6.ringer = {$yealink_ring_file_6}
+distinctive_ring_tones.alert_info.7.ringer = {$yealink_ring_file_7}
+distinctive_ring_tones.alert_info.8.ringer = {$yealink_ring_file_8}
+distinctive_ring_tones.alert_info.9.ringer = {$yealink_ring_file_9}
+distinctive_ring_tones.alert_info.10.ringer = {$yealink_ring_file_10} 
 
 #######################################################################################
 ##                                   Call Waiting                                    ##       


### PR DESCRIPTION
Adds new variables in Yealink provisioning templates to allow control of distinctive ring text and distinctive ringtone options.

New variables:
yealink_ring_text_X
yealink_ring_file_X

Setting affected:
distinctive_ring_tones.alert_info.X.text
distinctive_ring_tones.alert_info.X.ringer

Phones affected:
T1x
T2x
T3x
T4x
T5x

User Effect
This should not have any effect on existing provisioning settings unless the new variables are defined.