### PR TITLE
Fix Yealink Programmable Key Template Conflicts

### DIFF
--- a/resources/templates/provision/yealink/t21p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t21p/{$mac}.cfg
@@ -3024,46 +3024,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-
-
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#programablekey.1.type =
-#programablekey.1.line =
-#programablekey.1.value =
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t23g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t23g/{$mac}.cfg
@@ -2905,68 +2905,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 {/foreach}
 
-
-##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
 ##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################

--- a/resources/templates/provision/yealink/t23p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t23p/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t26p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t26p/{$mac}.cfg
@@ -2026,69 +2026,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t27g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t27g/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t27p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t27p/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t28p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t28p/{$mac}.cfg
@@ -2027,69 +2027,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t29g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t29g/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t32g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t32g/{$mac}.cfg
@@ -1979,36 +1979,6 @@ memorykey.{$row.device_key_id}.label = {$row.device_key_label}
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
- {/foreach}
-
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t38g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t38g/{$mac}.cfg
@@ -1971,35 +1971,6 @@ memorykey.{$row.device_key_id}.label = {$row.device_key_label}
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
- {/foreach}
-
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t40g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t40g/{$mac}.cfg
@@ -3012,67 +3012,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t40p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t40p/{$mac}.cfg
@@ -3012,67 +3012,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t41p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t41p/{$mac}.cfg
@@ -3012,67 +3012,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t41s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t41s/{$mac}.cfg
@@ -3012,67 +3012,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t42g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t42g/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t42s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t42s/{$mac}.cfg
@@ -3012,67 +3012,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t46g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46g/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t46s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46s/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t48g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t48g/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t48s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t48s/{$mac}.cfg
@@ -3012,67 +3012,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t49g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t49g/{$mac}.cfg
@@ -3012,67 +3012,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#N/A - Disable DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/vp530/{$mac}.cfg
+++ b/resources/templates/provision/yealink/vp530/{$mac}.cfg
@@ -3015,68 +3015,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.


### PR DESCRIPTION
Some Yealink templates had hard-coded programmable key settings in {$mac.cfg} files.

Since the ability to edit programmable keys was added in all y000000000000.cfg files in a previous pull request, all programmable key options in {$mac.cfg} have been removed to avoid configuration conflicts between the two files.